### PR TITLE
Update supported python to minimum 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'flake8-type-checking'
-version = '1.0.3'
+version = '1.0.4'
 description = 'A flake8 plugin for managing type-checking imports & forward references'
 homepage = 'https://github.com/snok'
 repository = 'https://github.com/sondrelg/flake8-type-checking'


### PR DESCRIPTION
A second fix for https://github.com/snok/flake8-type-checking/issues/34 and https://github.com/snok/flake8-type-checking/commit/ae69260264bd024a762d1b2adbfb809ddacf2b1e, which didn't upgrade the poetry python requirement

Fixes #34