### PR TITLE
Remove colon after codes in order to comply with "--format=%(code)s"

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,22 +118,22 @@ class B(Model):
 Will result in these errors
 
 ```shell
->> a.py: TC002: Move third-party import 'models.b.B' into a type-checking block
->> b.py: TC002: Move third-party import 'models.a.A' into a type-checking block
+>> a.py: TC002 Move third-party import 'models.b.B' into a type-checking block
+>> b.py: TC002 Move third-party import 'models.a.A' into a type-checking block
 ```
 
 and consequently trigger these errors if imports are purely moved into type-checking block, without proper forward reference handling
 
 ```shell
->> a.py: TC100: Add 'from __future__ import annotations' import
->> b.py: TC100: Add 'from __future__ import annotations' import
+>> a.py: TC100 Add 'from __future__ import annotations' import
+>> b.py: TC100 Add 'from __future__ import annotations' import
 ```
 
 or
 
 ```shell
->> a.py: TC200: Annotation 'B' needs to be made into a string literal
->> b.py: TC200: Annotation 'A' needs to be made into a string literal
+>> a.py: TC200 Annotation 'B' needs to be made into a string literal
+>> b.py: TC200 Annotation 'A' needs to be made into a string literal
 ```
 
 **Good code**

--- a/flake8_type_checking/codes.py
+++ b/flake8_type_checking/codes.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-TC001 = "TC001: Move import '{module}' into a type-checking block"
-TC002 = "TC002: Move third-party import '{module}' into a type-checking block"
-TC003 = 'TC003: Found multiple type checking blocks'
-TC004 = "TC004: Move import '{module}' out of type-checking block. Import is used for more than type hinting."
-TC005 = 'TC005: Found empty type-checking block'
-TC100 = "TC100: Add 'from __future__ import annotations' import"
-TC101 = "TC101: Annotation '{annotation}' does not need to be a string literal"
-TC200 = "TC200: Annotation '{annotation}' needs to be made into a string literal"
-TC201 = "TC201: Annotation '{annotation}' does not need to be a string literal"
+TC001 = "TC001 Move import '{module}' into a type-checking block"
+TC002 = "TC002 Move third-party import '{module}' into a type-checking block"
+TC003 = 'TC003 Found multiple type checking blocks'
+TC004 = "TC004 Move import '{module}' out of type-checking block. Import is used for more than type hinting."
+TC005 = 'TC005 Found empty type-checking block'
+TC100 = "TC100 Add 'from __future__ import annotations' import"
+TC101 = "TC101 Annotation '{annotation}' does not need to be a string literal"
+TC200 = "TC200 Annotation '{annotation}' needs to be made into a string literal"
+TC201 = "TC201 Annotation '{annotation}' does not need to be a string"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -127,7 +127,7 @@ class TestFoundBugs:
         var: x
         """
         )
-        assert _get_error(example) == {"7:4 TC002: Move third-party import 'x' into a type-checking block"}
+        assert _get_error(example) == {"7:4 TC002 Move third-party import 'x' into a type-checking block"}
 
 
 def test_import_is_local():

--- a/tests/test_should_warn.py
+++ b/tests/test_should_warn.py
@@ -33,7 +33,7 @@ def test_tc_is_enabled_with_config(flake8dir):
     )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        f".{os.sep}example.py:1:1: TC002: Move third-party import 'typing.Union' into a type-checking block"
+        f".{os.sep}example.py:1:1: TC002 Move third-party import 'typing.Union' into a type-checking block"
     ]
 
 
@@ -82,7 +82,7 @@ def test_tc1_works_when_opted_in(flake8dir):
     '''
     )
     result = flake8dir.run_flake8()
-    assert result.out_lines == [f".{os.sep}example.py:1:1: TC100: Add 'from __future__ import annotations' import"]
+    assert result.out_lines == [f".{os.sep}example.py:1:1: TC100 Add 'from __future__ import annotations' import"]
 
 
 def test_tc2_works_when_opted_in(flake8dir):
@@ -106,5 +106,5 @@ def test_tc2_works_when_opted_in(flake8dir):
     )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        f".{os.sep}example.py:6:4: TC200: Annotation 'Union' needs to be made into a string literal"
+        f".{os.sep}example.py:6:4: TC200 Annotation 'Union' needs to be made into a string literal"
     ]


### PR DESCRIPTION
Resolves #49 