### PR TITLE
TC005 logic fix

### DIFF
--- a/tests/test_tc005.py
+++ b/tests/test_tc005.py
@@ -68,6 +68,18 @@ examples = [
         ),
         set(),
     ),
+    (
+        textwrap.dedent(
+            """
+    from typing import TYPE_CHECKING
+    from typing import List
+
+    if TYPE_CHECKING:
+        x: List
+    """
+        ),
+        set(),
+    ),
 ]
 
 


### PR DESCRIPTION
TC005 is meant to catch residual empty type-checking blocks like this:
```python
if TYPE_CHECKING:
    pass
```

Right now the logic only checks for imports within a type-checking block and raises a TC005 if no imports are found. This is not quite right, since type-checking blocks are often used, e.g., within class scopes to override local types.

This PR changes the logic so it's even simpler. Now we only flag an error if the type-checking block only contains a pass statement.