### PR TITLE
feat: Add partial FastAPI support

### DIFF
--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -51,7 +51,14 @@ class Plugin:
             action='store_true',
             parse_from_config=True,
             default=False,
-            help='Add compatibility for Pydantic models.',
+            help='Prevent flagging of annotations for class definitions.',
+        )
+        option_manager.add_option(
+            '--type-checking-fastapi-enabled',
+            action='store_true',
+            parse_from_config=True,
+            default=True,
+            help='Prevent flagging of annotations for decorated functions.',
         )
 
     def run(self) -> Flake8Generator:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'flake8-type-checking'
-version = "1.2.0"
+version = "1.3.0"
 description = 'A flake8 plugin for managing type-checking imports & forward references'
 homepage = 'https://github.com/snok'
 repository = 'https://github.com/sondrelg/flake8-type-checking'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,7 @@ REPO_ROOT = Path(os.getcwd()).parent
 mod = 'flake8_type_checking'
 
 
-def _get_error(example: str, error_code_filter: Optional[str] = None, **kwargs: Any) -> set[str]:
+def _get_error(example: str, *, error_code_filter: Optional[str] = None, **kwargs: Any) -> set[str]:
     os.chdir(REPO_ROOT)
     if error_code_filter:
         mock_options = Mock()
@@ -22,9 +22,11 @@ def _get_error(example: str, error_code_filter: Optional[str] = None, **kwargs: 
         mock_options.enable_extensions = []
         mock_options.type_checking_pydantic_enabled = False
         mock_options.type_checking_exempt_modules = []
+        mock_options.type_checking_fastapi_enabled = False
         # kwarg overrides
         for k, v in kwargs.items():
             setattr(mock_options, k, v)
+        print(f'{mock_options.type_checking_fastapi_enabled=}')
         plugin = Plugin(ast.parse(example), options=mock_options)
     else:
         plugin = Plugin(ast.parse(example))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -158,7 +158,7 @@ def test_import_is_local():
     def raise_value_error(*args, **kwargs):
         raise ValueError('test')
 
-    visitor = ImportVisitor(REPO_ROOT, False)
+    visitor = ImportVisitor(REPO_ROOT, False, False)
     assert visitor._import_is_local(mod) is True
 
     patch('flake8_type_checking.checker.find_spec', raise_value_error).start()

--- a/tests/test_fastapi_decorators.py
+++ b/tests/test_fastapi_decorators.py
@@ -1,0 +1,107 @@
+"""
+This file tests FastAPI decorator support.
+
+See https://github.com/snok/flake8-type-checking/issues/52
+for discussion on the implementation.
+"""
+
+import textwrap
+
+import pytest
+
+from flake8_type_checking.codes import TC002
+from tests import _get_error
+
+defaults = {'type_checking_fastapi_enabled': True}
+
+
+@pytest.mark.parametrize('fdef', ['def', 'async def'])
+def test_api_router_decorated_function(fdef):
+    """
+    Test sync and async function definition, with an arg and a kwarg.
+    """
+    example = textwrap.dedent(
+        f'''
+        from fastapi import APIRouter
+
+        from app.models import SomeModel
+        from app.services import some_function
+        from app.types import CustomType
+
+        some_router = APIRouter(prefix='/some-path')
+
+        @some_router.get('/{{resource_id}}')
+        {fdef} list_something(resource_id: CustomType, some_model: SomeModel = Depends(some_function)):
+            return None
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002', **defaults) == set()
+
+
+@pytest.mark.parametrize('fdef', ['def', 'async def'])
+def test_api_router_decorated_function_return_type(fdef):
+    """
+    We don't care about return types. To my knowledge,
+    these are not evaluated by FastAPI/pydantic.
+    """
+    example = textwrap.dedent(
+        f'''
+        from fastapi import APIRouter
+        from fastapi import Request
+
+        from app.types import CustomType
+
+        some_router = APIRouter(prefix='/some-path')
+
+        @some_router.get('/{{resource_id}}')
+        {fdef} list_something(request: Request) -> CustomType:
+            return None
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002', **defaults) == {
+        '5:0 ' + TC002.format(module='app.types.CustomType')
+    }
+
+
+@pytest.mark.parametrize('fdef', ['def', 'async def'])
+def test_api_router_decorated_nested_function(fdef):
+    example = textwrap.dedent(
+        f'''
+        import logging
+
+        from typing import TYPE_CHECKING
+
+        from fastapi import APIRouter, Request
+
+        if TYPE_CHECKING:
+            from starlette.responses import RedirectResponse
+
+        logger = logging.getLogger(__name__)
+
+
+        def get_auth_router() -> APIRouter:
+            router = APIRouter(tags=['Auth'], include_in_schema=False)
+
+            @router.get('/login')
+            {fdef} login(request: Request) -> "RedirectResponse":
+                ...
+
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002', **defaults) == set()
+
+
+@pytest.mark.parametrize('fdef', ['def', 'async def'])
+def test_app_decorated_function(fdef):
+    example = textwrap.dedent(
+        f'''
+        from app.main import app
+        from app.models import SomeModel
+        from app.types import CustomType
+
+        @app.get('/{{resource_id}}')
+        {fdef} list_something(resource_id: CustomType, some_model: SomeModel = Depends(lambda: 1)):
+            return None
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002', **defaults) == set()

--- a/tests/test_import_visitors.py
+++ b/tests/test_import_visitors.py
@@ -10,13 +10,13 @@ from tests import REPO_ROOT
 
 
 def _get_remote_imports(example):
-    visitor = ImportVisitor(REPO_ROOT, False)
+    visitor = ImportVisitor(REPO_ROOT, False, False)
     visitor.visit(ast.parse(example.replace('; ', '\n')))
     return list(visitor.remote_imports.keys())
 
 
 def _get_local_imports(example):
-    visitor = ImportVisitor(REPO_ROOT, False)
+    visitor = ImportVisitor(REPO_ROOT, False, False)
     visitor.visit(ast.parse(example.replace('; ', '\n')))
     return list(visitor.local_imports.keys())
 

--- a/tests/test_name_visitor.py
+++ b/tests/test_name_visitor.py
@@ -8,7 +8,7 @@ from flake8_type_checking.checker import ImportVisitor
 
 
 def _get_names(example: str) -> Set[str]:
-    visitor = ImportVisitor('fake cwd', False)  # type: ignore
+    visitor = ImportVisitor('fake cwd', False, False)  # type: ignore
     visitor.visit(ast.parse(example))
     return visitor.names
 


### PR DESCRIPTION
Record decorated function argument and keyword argument
annotations as uses, to prevent flagging these as TC001
and TC002 errors. These are evaluated at runtime by FastAPI

This only handles decorated functions, meaning any annotation in 
a dependency function (any function passed to `Depends`) is still at risk 
of being flagged as a candidate for guarding, while being evaluated at runtime.

Re discussion in #52, I'm not 100% sure what design makes the most sense. Might
make FastAPI support include handling of just decorators and create a separate function
for dependencies (or vice versa).