### PR TITLE
refactor: Replace custom import classification with library

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -5,9 +5,10 @@ import os
 import sys
 from ast import Index
 from contextlib import suppress
-from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from aspy.refactor_imports.classify import ImportType, classify_import
 
 from flake8_type_checking.codes import TC001, TC002, TC003, TC004, TC005, TC100, TC101, TC200, TC201
 
@@ -171,42 +172,6 @@ class ImportVisitor(ast.NodeTransformer):
 
     # -- Map imports -------------------------------
 
-    def _import_is_local(self, import_name: str) -> bool:
-        """
-        Guess at whether an import is remote or a part of the local repo.
-
-        Not sure if there is a best-practice way of asserting whether an import is made from the current project.
-        The assumptions made below are:
-
-            1. It's definitely not a local imports if we can't import it
-            2. If we can import it, but 'venv' is in the path, it's not a local import
-            3. If the current working directory (where flake8 is called from) is not present in the parent
-            directories (excluding venv) it's probably a remote import (probably stdlib)
-
-        The second and third assumptions are not iron clad, and could
-        generate false positives, but should work for a first iteration.
-        """
-        try:
-            if '.' in import_name:
-                spec = find_spec('.'.join(import_name.split('.')[:-1]), import_name.split('.')[-1])
-            else:
-                spec = find_spec(import_name)
-        except ModuleNotFoundError:
-            return False
-        except possible_local_errors:
-            return True
-        except ValueError:
-            return False
-
-        if not spec:
-            return False
-
-        if not spec.origin or 'venv' in spec.origin:
-            return False
-
-        origin = Path(spec.origin)
-        return self.cwd in origin.parents
-
     def _add_import(self, node: Import) -> None:
         """
         Add relevant ast objects to import lists.
@@ -246,7 +211,6 @@ class ImportVisitor(ast.NodeTransformer):
                     # in a file, so we should only need to check this once
                     self.futures_annotation = False
 
-            # Map imports as belonging to the current module, or belonging to a third-party mod
             if name_node.name not in self.exempt_imports:
                 module = f'{node.module}.' if isinstance(node, ast.ImportFrom) else ''
                 if hasattr(name_node, 'asname') and name_node.asname:
@@ -255,12 +219,15 @@ class ImportVisitor(ast.NodeTransformer):
                 else:
                     name = name_node.name
                     import_name = module + name_node.name
-                is_local = self._import_is_local(f'{module}{name_node.name}')
-                if is_local:
+
+                import_class = classify_import(f'{module}{name_node.name}')
+
+                if import_class == ImportType.FUTURE:
+                    pass
+                elif import_class == ImportType.APPLICATION:
                     self.local_imports[import_name] = {'error': TC001, 'node': node}
                     self.import_names[name] = import_name, True
-
-                else:
+                elif import_class in [ImportType.BUILTIN, ImportType.THIRD_PARTY]:
                     self.remote_imports[import_name] = {'error': TC002, 'node': node}
                     self.import_names[name] = import_name, False
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "aspy.refactor-imports"
+version = "2.2.0"
+description = "Utilities for refactoring imports in python-like syntax."
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+cached-property = "*"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -33,6 +44,14 @@ name = "backcall"
 version = "0.2.0"
 description = "Specifications for callback functions passed in to an API"
 category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "cached-property"
+version = "1.5.2"
+description = "A decorator for caching properties in classes."
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -438,12 +457,16 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = '^3.8'
-content-hash = "56c3f17929d471db35e477ecc0181092b17e730f74a4c5e45f561e43798f9858"
+content-hash = "246032d8844fe3867505716f7375d53fc9795cb455bd89f6cb70cdf24fd39314"
 
 [metadata.files]
 appnope = [
     {file = "appnope-0.1.2-py2.py3-none-any.whl", hash = "sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442"},
     {file = "appnope-0.1.2.tar.gz", hash = "sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"},
+]
+"aspy.refactor-imports" = [
+    {file = "aspy.refactor_imports-2.2.0-py2.py3-none-any.whl", hash = "sha256:7a18039d2e8be6b02b4791ce98891deb46b459b575c52ed35ab818c4eaa0c098"},
+    {file = "aspy.refactor_imports-2.2.0.tar.gz", hash = "sha256:78ca24122963fd258ebfc4a8dc708d23a18040ee39dca8767675821e84e9ea0a"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -456,6 +479,10 @@ attrs = [
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+cached-property = [
+    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
+    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
 ]
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = '^3.8'
 flake8 = '*'
+"aspy.refactor-imports" = "^2.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = '^6.2.2'

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -148,19 +148,3 @@ class TestFoundBugs:
         """
         )
         assert _get_error(example) == {"7:4 TC002 Move third-party import 'x' into a type-checking block"}
-
-
-def test_import_is_local():
-    """
-    Check that if ValueErrors are raised in _import_is_local, we bump it into the TC002 bucket.
-    """
-
-    def raise_value_error(*args, **kwargs):
-        raise ValueError('test')
-
-    visitor = ImportVisitor(REPO_ROOT, False, False)
-    assert visitor._import_is_local(mod) is True
-
-    patch('flake8_type_checking.checker.find_spec', raise_value_error).start()
-    assert visitor._import_is_local(mod) is False
-    patch.stopall()


### PR DESCRIPTION
The import classification has always been a little sketchy. Replacing it with a library seems like an improvement.