### PR TITLE
Fix error when `enable_extensions` is not set

### DIFF
--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -110,9 +110,10 @@ class Plugin:
             return False
 
         for i in range(3, len(code) + 1):
-            if (
-                code[:i]
-                in self.options.select + list(self.options.extended_default_select) + self.options.enable_extensions
+            if code[:i] in (
+                self.options.select
+                + list(self.options.extended_default_select)
+                + (self.options.enable_extensions or [])
             ):
                 # Warn if opted-in
                 return True


### PR DESCRIPTION
I'm not sure exactly what triggered this (it doesn't always happen even when `enable_extensions` is unset), but I got the following traceback:

```pytb
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/home/nyuszika7h/.pyenv/versions/3.10.1/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/nyuszika7h/.pyenv/versions/3.10.1/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File ".venv/lib/python3.10/site-packages/flake8/checker.py", line 621, in _run_checks
    return checker.run_checks()
  File ".venv/lib/python3.10/site-packages/flake8/checker.py", line 531, in run_checks
    self.run_ast_checks()
  File ".venv/lib/python3.10/site-packages/flake8/checker.py", line 435, in run_ast_checks
    for (line_number, offset, text, _) in runner:
  File ".venv/lib/python3.10/site-packages/flake8_type_checking/plugin.py", line 83, in run
    if self.should_warn(e[2].split(':')[0]):
  File ".venv/lib/python3.10/site-packages/flake8_type_checking/plugin.py", line 115, in should_warn
    in self.options.select + list(self.options.extended_default_select) + self.options.enable_extensions
TypeError: can only concatenate list (not "NoneType") to list
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File ".venv/bin/flake8", line 8, in <module>
    sys.exit(main())
  File ".venv/lib/python3.10/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File ".venv/lib/python3.10/site-packages/flake8/main/application.py", line 336, in run
    self._run(argv)
  File ".venv/lib/python3.10/site-packages/flake8/main/application.py", line 325, in _run
    self.run_checks()
  File ".venv/lib/python3.10/site-packages/flake8/main/application.py", line 229, in run_checks
    self.file_checker_manager.run()
  File ".venv/lib/python3.10/site-packages/flake8/checker.py", line 250, in run
    self.run_parallel()
  File ".venv/lib/python3.10/site-packages/flake8/checker.py", line 217, in run_parallel
    for ret in pool_map:
  File "/home/nyuszika7h/.pyenv/versions/3.10.1/lib/python3.10/multiprocessing/pool.py", line 448, in <genexpr>
    return (item for chunk in result for item in chunk)
  File "/home/nyuszika7h/.pyenv/versions/3.10.1/lib/python3.10/multiprocessing/pool.py", line 870, in next
    raise value
TypeError: can only concatenate list (not "NoneType") to list
```

This pull request ensures it doesn't happen by defaulting `self.options.enable_extensions` to an empty list.