### PR TITLE
Proposal to implement `attrs` support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: black
         args: [ "--quiet" ]
+        additional_dependencies: ['click==8.0.4']
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ ignore=
     # D107 Missing docstring in __init__
     D107,
     # ANN101 Missing type annotation for self/cls in method
-    ANN101, ANN102
+    ANN101, ANN102, ANN401
     # W503 line break before binary operator
     W503,
     SIM110

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -1,0 +1,197 @@
+"""
+This file tests attrs support.
+
+See https://github.com/snok/flake8-type-checking/issues/77
+for discussion on the implementation.
+"""
+
+import textwrap
+
+import pytest
+
+from flake8_type_checking.codes import TC002
+from tests import _get_error
+
+
+@pytest.mark.parametrize(
+    'expected',
+    (
+        {'2:0 ' + TC002.format(module='decimal.Decimal')},
+        {'2:0 ' + TC002.format(module='decimal.Decimal')},
+    ),
+)
+def test_non_attrs_model(expected):
+    example = textwrap.dedent(
+        '''
+        from decimal import Decimal
+
+        class X:
+            x: Decimal
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002') == expected
+
+@pytest.mark.parametrize(
+    'imp, dec',
+    (
+        ["import attrs", "@attrs.define"],
+        ["import attr", "@attr.s(auto_attribs=True)"],
+        ["import attr", "@attr.define"],
+    ),
+)
+def test_attrs_model(imp, dec):
+    """
+    A class cannot be a attrs model if it doesn't have a base class,
+    so we should raise the same error here in both cases.
+    """
+    example = textwrap.dedent(
+        f'''
+        {imp}
+        from decimal import Decimal
+
+        {dec}
+        class X:
+            x: Decimal
+
+        {dec}
+        class Y:
+            x: Decimal
+
+        class Z:
+            x: Decimal
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002') == set()
+
+@pytest.mark.parametrize(
+    'imp, dec, expected',
+    (
+        ["import attrs", "@attrs.define", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["import attr", "@attr.s(auto_attribs=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["import attr", "@attr.define", {'4:0 ' + TC002.format(module='decimal.Context')}],
+    ),
+)
+def test_complex_attrs_model(imp, dec, expected):
+    """
+    A class cannot be a attrs model if it doesn't have a base class,
+    so we should raise the same error here in both cases.
+    """
+    example = textwrap.dedent(
+        f'''
+        {imp}
+        from decimal import Decimal
+        from decimal import Context
+
+        {dec}
+        class X:
+            x: Decimal
+
+        {dec}
+        class Y:
+            x: Decimal
+
+        class Z:
+            x: Context
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002') == expected
+
+@pytest.mark.parametrize(
+    'imp, dec, expected',
+    (
+        ["from attrs import define", "@define", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["from attr import s", "@s(auto_attribs=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["from attr import define", "@define", {'4:0 ' + TC002.format(module='decimal.Context')}],
+    ),
+)
+def test_complex_attrs_model_direct_import(imp, dec, expected):
+    """
+    A class cannot be a attrs model if it doesn't have a base class,
+    so we should raise the same error here in both cases.
+    """
+    example = textwrap.dedent(
+        f'''
+        {imp}
+        from decimal import Decimal
+        from decimal import Context
+
+        {dec}
+        class X:
+            x: Decimal
+
+        {dec}
+        class Y:
+            x: Decimal
+
+        class Z:
+            x: Context
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002') == expected
+
+@pytest.mark.parametrize(
+    'imp, dec, expected',
+    (
+        ["from attrs import define as asdfg", "@asdfg", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["from attr import s as ghdjfg", "@ghdjfg(auto_attribs=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["import attr.define as adasdfg", "@adasdfg", {'4:0 ' + TC002.format(module='decimal.Context')}],
+    ),
+)
+def test_complex_attrs_model_as_import(imp, dec, expected):
+    """
+    A class cannot be a attrs model if it doesn't have a base class,
+    so we should raise the same error here in both cases.
+    """
+    example = textwrap.dedent(
+        f'''
+        {imp}
+        from decimal import Decimal
+        from decimal import Context
+
+        {dec}
+        class X:
+            x: Decimal
+
+        {dec}
+        class Y:
+            x: Decimal
+
+        class Z:
+            x: Context
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002') == expected
+
+@pytest.mark.parametrize(
+    'imp, dec, expected',
+    (
+        ["from attr import define", "@define(slots=False)", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["from attr import define", "@define(frozen=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["from attr import define", "@define(slots=False, frozen=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ["import attr", "@attr.define(slots=False, frozen=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
+    ),
+)
+def test_complex_attrs_model_slots_frozen(imp, dec, expected):
+    """
+    A class cannot be a attrs model if it doesn't have a base class,
+    so we should raise the same error here in both cases.
+    """
+    example = textwrap.dedent(
+        f'''
+        {imp}
+        from decimal import Decimal
+        from decimal import Context
+
+        {dec}
+        class X:
+            x: Decimal
+
+        {dec}
+        class Y:
+            x: Decimal
+
+        class Z:
+            x: Context
+        '''
+    )
+    assert _get_error(example, error_code_filter='TC001,TC002') == expected

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -14,35 +14,17 @@ from tests import _get_error
 
 
 @pytest.mark.parametrize(
-    'expected',
-    (
-        {'2:0 ' + TC002.format(module='decimal.Decimal')},
-        {'2:0 ' + TC002.format(module='decimal.Decimal')},
-    ),
-)
-def test_non_attrs_model(expected):
-    example = textwrap.dedent(
-        '''
-        from decimal import Decimal
-
-        class X:
-            x: Decimal
-        '''
-    )
-    assert _get_error(example, error_code_filter='TC001,TC002') == expected
-
-@pytest.mark.parametrize(
     'imp, dec',
     (
-        ["import attrs", "@attrs.define"],
-        ["import attr", "@attr.s(auto_attribs=True)"],
-        ["import attr", "@attr.define"],
+        ['import attrs', '@attrs.define'],
+        ['import attr', '@attr.s(auto_attribs=True)'],
+        ['import attr', '@attr.define'],
     ),
 )
 def test_attrs_model(imp, dec):
     """
-    A class cannot be a attrs model if it doesn't have a base class,
-    so we should raise the same error here in both cases.
+    Test `attrs` classes together with a non-`attrs` class that has a class var of the same type.
+    `attrs` classes are instantiated using different dataclass decorators. The `attrs` module is imported as whole.
     """
     example = textwrap.dedent(
         f'''
@@ -63,18 +45,19 @@ def test_attrs_model(imp, dec):
     )
     assert _get_error(example, error_code_filter='TC001,TC002') == set()
 
+
 @pytest.mark.parametrize(
     'imp, dec, expected',
     (
-        ["import attrs", "@attrs.define", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["import attr", "@attr.s(auto_attribs=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["import attr", "@attr.define", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['import attrs', '@attrs.define', {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['import attr', '@attr.s(auto_attribs=True)', {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['import attr', '@attr.define', {'4:0 ' + TC002.format(module='decimal.Context')}],
     ),
 )
 def test_complex_attrs_model(imp, dec, expected):
     """
-    A class cannot be a attrs model if it doesn't have a base class,
-    so we should raise the same error here in both cases.
+    Test `attrs` classes together with a non-`attrs` class tha has a class var of another type.
+    `attrs` classes are instantiated using different dataclass decorators. The `attrs` module is imported as whole.
     """
     example = textwrap.dedent(
         f'''
@@ -96,18 +79,19 @@ def test_complex_attrs_model(imp, dec, expected):
     )
     assert _get_error(example, error_code_filter='TC001,TC002') == expected
 
+
 @pytest.mark.parametrize(
     'imp, dec, expected',
     (
-        ["from attrs import define", "@define", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["from attr import s", "@s(auto_attribs=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["from attr import define", "@define", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['from attrs import define', '@define', {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['from attr import s', '@s(auto_attribs=True)', {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['from attr import define', '@define', {'4:0 ' + TC002.format(module='decimal.Context')}],
     ),
 )
 def test_complex_attrs_model_direct_import(imp, dec, expected):
     """
-    A class cannot be a attrs model if it doesn't have a base class,
-    so we should raise the same error here in both cases.
+    Test `attrs` classes together with a non-`attrs` class tha has a class var of another type.
+    `attrs` classes are instantiated using different dataclass decorators which are imported as submodules.
     """
     example = textwrap.dedent(
         f'''
@@ -129,18 +113,24 @@ def test_complex_attrs_model_direct_import(imp, dec, expected):
     )
     assert _get_error(example, error_code_filter='TC001,TC002') == expected
 
+
 @pytest.mark.parametrize(
     'imp, dec, expected',
     (
-        ["from attrs import define as asdfg", "@asdfg", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["from attr import s as ghdjfg", "@ghdjfg(auto_attribs=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["import attr.define as adasdfg", "@adasdfg", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['from attrs import define as asdfg', '@asdfg', {'4:0 ' + TC002.format(module='decimal.Context')}],
+        [
+            'from attr import s as ghdjfg',
+            '@ghdjfg(auto_attribs=True)',
+            {'4:0 ' + TC002.format(module='decimal.Context')},
+        ],
+        ['import attr as ghdjfg', '@ghdjfg.define', {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['import attr.define as adasdfg', '@adasdfg', {'4:0 ' + TC002.format(module='decimal.Context')}],
     ),
 )
 def test_complex_attrs_model_as_import(imp, dec, expected):
     """
-    A class cannot be a attrs model if it doesn't have a base class,
-    so we should raise the same error here in both cases.
+    Test `attrs` classes together with a non-`attrs` class tha has a class var of another type.
+    `attrs` classes are instantiated using different dataclass decorators which are imported as submodules using an alias.
     """
     example = textwrap.dedent(
         f'''
@@ -162,19 +152,24 @@ def test_complex_attrs_model_as_import(imp, dec, expected):
     )
     assert _get_error(example, error_code_filter='TC001,TC002') == expected
 
+
 @pytest.mark.parametrize(
     'imp, dec, expected',
     (
-        ["from attr import define", "@define(slots=False)", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["from attr import define", "@define(frozen=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["from attr import define", "@define(slots=False, frozen=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
-        ["import attr", "@attr.define(slots=False, frozen=True)", {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['from attr import define', '@define(slots=False)', {'4:0 ' + TC002.format(module='decimal.Context')}],
+        ['from attr import define', '@define(frozen=True)', {'4:0 ' + TC002.format(module='decimal.Context')}],
+        [
+            'from attr import define',
+            '@define(slots=False, frozen=True)',
+            {'4:0 ' + TC002.format(module='decimal.Context')},
+        ],
+        ['import attr', '@attr.define(slots=False, frozen=True)', {'4:0 ' + TC002.format(module='decimal.Context')}],
     ),
 )
 def test_complex_attrs_model_slots_frozen(imp, dec, expected):
     """
-    A class cannot be a attrs model if it doesn't have a base class,
-    so we should raise the same error here in both cases.
+    Test `attrs` classes together with a non-`attrs` class tha has a class var of another type.
+    `attrs` classes are instantiated using different dataclass decorators and arguments.
     """
     example = textwrap.dedent(
         f'''


### PR DESCRIPTION
- implemented a method that compiles imports in regard to `attrs` including their import alias
- check at class definitions if any decorator is one of `attrs` dataclass decorators (matched against the actual import alias)