### PR TITLE
Add cattrs settings

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,7 @@ jobs:
         id: cache-venv
         with:
           path: .venv
-          key: venv-2  # increment to reset
+          key: venv-3  # increment to reset
       - run: |
           python -m venv .venv --upgrade-deps
           source .venv/bin/activate
@@ -28,7 +28,7 @@ jobs:
         id: pre-commit-cache
         with:
           path: ~/.cache/pre-commit
-          key: ${{ hashFiles('**/pre-commit-config.yaml') }}-2
+          key: ${{ hashFiles('**/pre-commit-config.yaml') }}-3
       - run: |
           source .venv/bin/activate
           pre-commit run --all-files
@@ -48,7 +48,7 @@ jobs:
         id: poetry-cache
         with:
           path: ~/.local
-          key: key-12
+          key: key-13
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
@@ -58,7 +58,7 @@ jobs:
         id: cache-venv
         with:
           path: .venv
-          key: ${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}-2
+          key: ${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}-3
       - run: |
           python -m venv .venv
           source .venv/bin/activate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,8 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        args: [ "--quiet" ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-ast
       - id: check-added-large-files
@@ -36,7 +35,7 @@ repos:
             'flake8-type-checking',
         ]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         args: [ "--py36-plus", "--py37-plus",'--keep-runtime-typing' ]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ More examples can be found in the [examples](#examples) section.
 
 <br>
 
-If you're using [pydantic](https://pydantic-docs.helpmanual.io/) or [fastapi](https://fastapi.tiangolo.com/),
+If you're using [pydantic](https://pydantic-docs.helpmanual.io/),
+[fastapi](https://fastapi.tiangolo.com/), or [cattrs](https://github.com/python-attrs/cattrs)
 see the [configuration](#configuration) for how to enable support.
 
 ## Primary features
@@ -198,6 +199,26 @@ Enabling dependency support will also enable FastAPI and Pydantic support.
 [flake8]
 type-checking-fastapi-dependency-support-enabled: true  # default false
 ```
+
+### Cattrs support
+
+If you're using the plugin in a project which uses `cattrs`,
+you can enable support. This will treat the annotations
+of any decorated `attrs` class as needed at runtime, since
+`cattrs.unstructure` calls will fail when loading
+classes where types are not available at runtime.
+
+Note: the cattrs support setting does not yet detect and
+ignore class var annotations on dataclasses or other non-attrs class types.
+This can be added in the future if needed.
+
+- **name**: `type-checking-cattrs-enabled`
+- **type**: `bool`
+```ini
+[flake8]
+type-checking-cattrs-enabled = true  # default false
+```
+
 
 ## Rationale
 

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -706,7 +706,7 @@ class TypingOnlyImportsChecker:
         """TC101."""
         # If futures imports are present, any ast.Constant captured in _add_annotation should yield an error
         if self.visitor.futures_annotation:
-            for (lineno, col_offset, annotation) in self.visitor.wrapped_annotations:
+            for lineno, col_offset, annotation in self.visitor.wrapped_annotations:
                 yield lineno, col_offset, TC101.format(annotation=annotation), None
         else:
             """
@@ -731,7 +731,7 @@ class TypingOnlyImportsChecker:
 
             For anyone with more insight into how this might be tackled, contributions are very welcome.
             """
-            for (lineno, col_offset, annotation) in self.visitor.wrapped_annotations:
+            for lineno, col_offset, annotation in self.visitor.wrapped_annotations:
                 for _, import_name in self.visitor.type_checking_block_imports:
                     if import_name in annotation:
                         break
@@ -745,14 +745,14 @@ class TypingOnlyImportsChecker:
 
     def missing_quotes(self) -> Flake8Generator:
         """TC200."""
-        for (lineno, col_offset, annotation) in self.visitor.unwrapped_annotations:
+        for lineno, col_offset, annotation in self.visitor.unwrapped_annotations:
             for _, name in self.visitor.type_checking_block_imports:
                 if annotation == name:
                     yield lineno, col_offset, TC200.format(annotation=annotation), None
 
     def excess_quotes(self) -> Flake8Generator:
         """TC201."""
-        for (lineno, col_offset, annotation) in self.visitor.wrapped_annotations:
+        for lineno, col_offset, annotation in self.visitor.wrapped_annotations:
             # See comment in futures_excess_quotes
             for _, import_name in self.visitor.type_checking_block_imports:
                 if import_name in annotation:

--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -75,6 +75,13 @@ class Plugin:
             default=False,
             help='Prevent flagging of annotations for any function.',
         )
+        option_manager.add_option(
+            '--type-checking-cattrs-enabled',
+            action='store_true',
+            parse_from_config=True,
+            default=False,
+            help='Prevent flagging of annotations on attrs class definitions.',
+        )
 
     def run(self) -> Flake8Generator:
         """Run flake8 plugin and return any relevant errors."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'flake8-type-checking'
-version = "1.4.0"
+version = "1.5.0"
 description = 'A flake8 plugin for managing type-checking imports & forward references'
 homepage = 'https://github.com/snok'
 repository = 'https://github.com/sondrelg/flake8-type-checking'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ build-backend = 'poetry.core.masonry.api'
 quiet = true
 line-length = 120
 skip-string-normalization = true
-experimental-string-processing = true
+preview = true
 
 [tool.isort]
 profile = "black"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -199,7 +199,14 @@ def test_import_is_local():
     def raise_value_error(*args, **kwargs):
         raise ValueError('test')
 
-    visitor = ImportVisitor(REPO_ROOT, False, False, False, [])
+    visitor = ImportVisitor(
+        cwd=REPO_ROOT,
+        pydantic_enabled=False,
+        fastapi_enabled=False,
+        fastapi_dependency_support_enabled=False,
+        cattrs_enabled=False,
+        pydantic_enabled_baseclass_passlist=[],
+    )
     assert visitor._import_is_local(mod) is True
 
     patch('flake8_type_checking.checker.find_spec', raise_value_error).start()

--- a/tests/test_import_visitors.py
+++ b/tests/test_import_visitors.py
@@ -10,13 +10,27 @@ from tests import REPO_ROOT
 
 
 def _get_remote_imports(example):
-    visitor = ImportVisitor(REPO_ROOT, False, False, False, [])
+    visitor = ImportVisitor(
+        cwd=REPO_ROOT,
+        pydantic_enabled=False,
+        fastapi_enabled=False,
+        fastapi_dependency_support_enabled=False,
+        cattrs_enabled=False,
+        pydantic_enabled_baseclass_passlist=[],
+    )
     visitor.visit(ast.parse(example.replace('; ', '\n')))
     return list(visitor.remote_imports.keys())
 
 
 def _get_local_imports(example):
-    visitor = ImportVisitor(REPO_ROOT, False, False, False, [])
+    visitor = ImportVisitor(
+        cwd=REPO_ROOT,
+        pydantic_enabled=False,
+        fastapi_enabled=False,
+        fastapi_dependency_support_enabled=False,
+        cattrs_enabled=False,
+        pydantic_enabled_baseclass_passlist=[],
+    )
     visitor.visit(ast.parse(example.replace('; ', '\n')))
     return list(visitor.local_imports.keys())
 

--- a/tests/test_name_visitor.py
+++ b/tests/test_name_visitor.py
@@ -8,7 +8,14 @@ from flake8_type_checking.checker import ImportVisitor
 
 
 def _get_names(example: str) -> Set[str]:
-    visitor = ImportVisitor('fake cwd', False, False, False, [])  # type: ignore[arg-type]
+    visitor = ImportVisitor(
+        cwd='fake cwd',  # type: ignore[arg-type]
+        pydantic_enabled=False,
+        fastapi_enabled=False,
+        fastapi_dependency_support_enabled=False,
+        cattrs_enabled=False,
+        pydantic_enabled_baseclass_passlist=[],
+    )
     visitor.visit(ast.parse(example))
     return visitor.names
 


### PR DESCRIPTION
Makes the attrs logic added for v1.4.0 opt-in, using the `cattrs-enabled` setting.

For complete `cattrs` support we should also add dataclass detection, but I'm happy with leaving it partially implemented for now. Seems more important to fix unnecessarily ignoring attrs definitions for now.  