### PR TITLE
fix: Pass copied tree to checker class

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,7 @@ jobs:
         id: cache-venv
         with:
           path: .venv
-          key: venv-2  # increment to reset
+          key: venv-3  # increment to reset
       - run: |
           python -m venv .venv --upgrade-deps
           source .venv/bin/activate
@@ -28,7 +28,7 @@ jobs:
         id: pre-commit-cache
         with:
           path: ~/.cache/pre-commit
-          key: ${{ hashFiles('**/pre-commit-config.yaml') }}-2
+          key: ${{ hashFiles('**/pre-commit-config.yaml') }}-3
       - run: |
           source .venv/bin/activate
           pre-commit run --all-files
@@ -48,7 +48,7 @@ jobs:
         id: poetry-cache
         with:
           path: ~/.local
-          key: key-12
+          key: key-13
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
@@ -58,7 +58,7 @@ jobs:
         id: cache-venv
         with:
           path: .venv
-          key: ${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}-2
+          key: ${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}-3
       - run: |
           python -m venv .venv
           source .venv/bin/activate

--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
+import pickle
 import sys
-from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from flake8_type_checking.checker import TypingOnlyImportsChecker
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from flake8.options.manager import OptionManager
 
     from flake8_type_checking.types import Flake8Generator
-
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import version
@@ -79,7 +78,7 @@ class Plugin:
 
     def run(self) -> Flake8Generator:
         """Run flake8 plugin and return any relevant errors."""
-        visitor = TypingOnlyImportsChecker(deepcopy(self._tree), self.options)
+        visitor = TypingOnlyImportsChecker(pickle.loads(pickle.dumps(self._tree, -1)), self.options)
         for e in visitor.errors:
             if self.should_warn(e[2].split(':')[0]):
                 yield e

--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from flake8_type_checking.checker import TypingOnlyImportsChecker
@@ -78,7 +79,7 @@ class Plugin:
 
     def run(self) -> Flake8Generator:
         """Run flake8 plugin and return any relevant errors."""
-        visitor = TypingOnlyImportsChecker(self._tree, self.options)
+        visitor = TypingOnlyImportsChecker(deepcopy(self._tree), self.options)
         for e in visitor.errors:
             if self.should_warn(e[2].split(':')[0]):
                 yield e


### PR DESCRIPTION
We do modify the tree quite a bit in the
checker, and that seems to lead to issues,
as documented in #71. This fixes the
example documented in the issue.