### PR TITLE
Flag imports on a per-module basis

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,12 +13,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.10.5"
       - uses: actions/cache@v2
         id: cache-venv
         with:
           path: .venv
-          key: venv-3  # increment to reset
+          key: venv-4  # increment to reset
       - run: |
           python -m venv .venv --upgrade-deps
           source .venv/bin/activate
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8.12", "3.9.13", "3.10.5" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8.12", "3.9.13", "3.10.5" ]
+        python-version: [ "3.8.12", "3.9.13", "3.10.5", "3.11.0-beta.3" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-ast
       - id: check-added-large-files
@@ -34,7 +34,7 @@ repos:
             'flake8-type-checking',
         ]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         args: [ "--py36-plus", "--py37-plus", "--py38-plus", '--keep-runtime-typing' ]
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.961
     hooks:
       - id: mypy
         args:

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -177,6 +177,7 @@ class FastAPIMixin(MixinBase):  # type: ignore
     For FastAPI app/route-decorated views, and for dependencies, we want
     to treat annotations as needed at runtime.
     """
+
     fastapi_enabled: bool
     fastapi_dependency_support_enabled: bool
 
@@ -226,6 +227,15 @@ class ImportName:
     _module: str
     _name: str
     _alias: Optional[str]
+
+    @property
+    def module(self) -> str:
+        """
+        Return the import module.
+
+        The self._module value contains a trailing ".".
+        """
+        return self._module.rstrip('.')
 
     @property
     def name(self) -> str:

--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -40,8 +40,10 @@ class Plugin:
             comma_separated_list=True,
             parse_from_config=True,
             default=[],
-            help='Skip TC001 and TC002 checks for specified modules or libraries.',
+            help='Skip TC001, TC002, and TC003 checks for specified modules or libraries.',
         )
+
+        # Third-party library options
         option_manager.add_option(
             '--type-checking-pydantic-enabled',
             action='store_true',
@@ -79,7 +81,13 @@ class Plugin:
         )
 
     def run(self) -> Flake8Generator:
-        """Run flake8 plugin and return any relevant errors."""
+        """
+        Run flake8 plugin and return any relevant errors.
+
+        We use pickle.loads/dumps here as a more performant alternative to deepcopy,
+        since we mutate the tree we receive and not copying it like this will lead
+        to errors in consequent plugins.
+        """
         visitor = TypingOnlyImportsChecker(pickle.loads(pickle.dumps(self._tree, -1)), self.options)
         for e in visitor.errors:
             if self.should_warn(e[2].split(':')[0]):

--- a/flake8_type_checking/types.py
+++ b/flake8_type_checking/types.py
@@ -1,11 +1,10 @@
-# flake8: noqa: D101
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Optional, Protocol
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     import ast
-    from typing import Any, Generator, Tuple, TypedDict, Union
+    from typing import Any, Generator, Optional, Protocol, Tuple, TypedDict, Union
 
     class FunctionRangesDict(TypedDict):
         start: int

--- a/flake8_type_checking/types.py
+++ b/flake8_type_checking/types.py
@@ -7,10 +7,6 @@ if TYPE_CHECKING:
     import ast
     from typing import Any, Generator, Tuple, TypedDict, Union
 
-    class ErrorDict(TypedDict):
-        error: str
-        node: ast.AST
-
     class FunctionRangesDict(TypedDict):
         start: int
         end: int

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,7 +65,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
@@ -419,7 +419,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "traitlets"
-version = "5.2.2.post1"
+version = "5.3.0"
 description = ""
 category = "dev"
 optional = false
@@ -489,8 +489,8 @@ cfgv = [
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -698,8 +698,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 traitlets = [
-    {file = "traitlets-5.2.2.post1-py3-none-any.whl", hash = "sha256:1530d04badddc6a73d50b7ee34667d4b96914da352109117b4280cb56523a51b"},
-    {file = "traitlets-5.2.2.post1.tar.gz", hash = "sha256:74803a1baa59af70f023671d86d5c7a834c931186df26d50d362ee6a1ff021fd"},
+    {file = "traitlets-5.3.0-py3-none-any.whl", hash = "sha256:65fa18961659635933100db8ca120ef6220555286949774b9cfc106f941d1c7a"},
+    {file = "traitlets-5.3.0.tar.gz", hash = "sha256:0bb9f1f9f017aa8ec187d8b1b2a7a6626a2a1d877116baba52a129bfa124f8e2"},
 ]
 virtualenv = [
     {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ exclude =
 
 per-file-ignores =
     flake8_type_checking/checker.py:SIM114
+    flake8_type_checking/types.py:D101
     tests/**.py:D103,D205,D400,D102,D101
 max-complexity = 18
 max-line-length = 120

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -62,7 +62,7 @@ def test_complex_attrs_model(imp, dec, expected):
     example = textwrap.dedent(
         f'''
         {imp}
-        from decimal import Decimal
+        from decimals import Decimal
         from decimal import Context
 
         {dec}
@@ -96,7 +96,7 @@ def test_complex_attrs_model_direct_import(imp, dec, expected):
     example = textwrap.dedent(
         f'''
         {imp}
-        from decimal import Decimal
+        from decimals import Decimal
         from decimal import Context
 
         {dec}
@@ -137,7 +137,7 @@ def test_complex_attrs_model_as_import(imp, dec, expected):
     example = textwrap.dedent(
         f'''
         {imp}
-        from decimal import Decimal
+        from decimals import Decimal
         from decimal import Context
 
         {dec}
@@ -176,7 +176,7 @@ def test_complex_attrs_model_slots_frozen(imp, dec, expected):
     example = textwrap.dedent(
         f'''
         {imp}
-        from decimal import Decimal
+        from decimals import Decimal
         from decimal import Context
 
         {dec}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -179,3 +179,18 @@ class TestFoundBugs:
             """
         for example in [type_checking, typing_type_checking, alias, aliased_typing]:
             assert _get_error(textwrap.dedent(example)) == set()
+
+    def test_import_not_flagged_when_existing_import_present(self):
+        """
+        When an import is made to a module, we treat it as already used.
+
+        Guarding additional imports to the same module shouldn't present
+        a performance gain of note, so it's probably not worth the effort.
+        """
+        example = """
+            from os import x  # <-- would otherwise be flagged
+            from os import y  # <-- but this should prevent that
+
+            z = y
+            """
+        assert _get_error(textwrap.dedent(example)) == set()


### PR DESCRIPTION
PR implements the change in behaviour suggested in #84. Where we have previously flagged unused imports, we will now flag unused imports only if there are no other used imports from the same module.  