### PR TITLE
fix: Add recursion limit override for copy

### DIFF
--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import logging
-import pickle
-import sys
 from typing import TYPE_CHECKING
 
 from flake8_type_checking.checker import TypingOnlyImportsChecker
 
 if TYPE_CHECKING:
-    from types import TracebackType
 
     from argparse import Namespace
     from ast import Module
@@ -21,29 +18,6 @@ if TYPE_CHECKING:
 from importlib.metadata import version
 
 logger = logging.getLogger('flake8.type_checking')
-
-
-class RecursionLimit:
-    """
-    Recursion limit context manager.
-
-    Copying ast trees can sometimes exceed the default recursion limit,
-    so this lets us temporarily increase it, just for that operation.
-    """
-
-    def __init__(self, n: int):
-        self.current_limit = sys.getrecursionlimit()
-        self.limit = n
-
-    def __enter__(self) -> None:
-        """Increase recursion limit."""
-        sys.setrecursionlimit(self.limit)
-
-    def __exit__(
-        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
-    ) -> None:
-        """Reset recursion limit."""
-        sys.setrecursionlimit(self.current_limit)
 
 
 class Plugin:
@@ -107,17 +81,8 @@ class Plugin:
         )
 
     def run(self) -> Flake8Generator:
-        """
-        Run flake8 plugin and return any relevant errors.
-
-        We use pickle.loads/dumps here as a more performant alternative to deepcopy,
-        since we mutate the tree we receive and not copying it like this will lead
-        to errors in consequent plugins.
-        """
-        with RecursionLimit(10_000):
-            copied_tree = pickle.loads(pickle.dumps(self._tree, -1))
-
-        visitor = TypingOnlyImportsChecker(copied_tree, self.options)
+        """Run flake8 plugin and return any relevant errors."""
+        visitor = TypingOnlyImportsChecker(self._tree, self.options)
 
         for e in visitor.errors:
             if self.should_warn(e[2].split(':')[0]):


### PR DESCRIPTION
~Running flake8-type-checking on a larger work project, I'm seeing recursion limit errors in the ast-tree copying. It's not an infinite recursion issue, as increasing the limit to 3-4000 seems to resolve it. From what I can tell, increasing the recursion limit can lead to segfaults if the recursion limit exceeds the system limit, but that 10,000 should be very conservative.~

~We added the copying because of #71, and ideally it would be nice to keep that in, so this seems like the best option. At the same time, I'm open to input/suggestions for how to resolve this in a better way. Tinkering with sys settings seems a little out of scope for a linter plugin.~

After trying to reproduce #71 in the latest Pytest release + [b3f22c4](https://github.com/snok/flake8-type-checking/pull/89/commits/b3f22c453b8352d9946d861668fd984e49364738), I'm actually not able to, so I think I will remove the entire copy.