### PR TITLE
Fix error code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ And depending on which error code range you've opted into, it will tell you
 |--------|------------------------------------------------------------------------------------|
 | TC001 | Move application import into a type-checking block                                 |
 | TC002 | Move third-party import into a type-checking block                                 |
-| TC002 | Move built-in import into a type-checking block                                    |
+| TC003 | Move built-in import into a type-checking block                                    |
 | TC004 | Move import out of type-checking block. Import is used for more than type hinting. |
 | TC005 | Empty type-checking block                                                          |
 


### PR DESCRIPTION
Judging from what's in the 2.0.0 release notes here, TC002 is for third-party, and TC003 is for built-in, so this updates the README to reflect that.