### PR TITLE
fix: handle annotations in positional-only args

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -671,7 +671,7 @@ class ImportVisitor(DunderAllMixin, AttrsMixin, FastAPIMixin, ast.NodeVisitor):
 
         And we also note down the start and end line number for the function.
         """
-        for path in [node.args.args, node.args.kwonlyargs]:
+        for path in [node.args.args, node.args.kwonlyargs, node.args.posonlyargs]:
             for argument in path:
                 if hasattr(argument, 'annotation') and argument.annotation:
                     self.add_annotation(argument.annotation)

--- a/tests/test_tc004.py
+++ b/tests/test_tc004.py
@@ -70,6 +70,18 @@ examples = [
         ),
         set(),
     ),
+    (
+        textwrap.dedent(
+            """
+    if TYPE_CHECKING:
+        from typing import List, Sequence, Set
+
+    def example(a: List[int], /, b: Sequence[int], *, c: Set[int]):
+        return
+    """
+        ),
+        set(),
+    ),
     # Used different places, but where each function scope has it's own import
     (
         textwrap.dedent(


### PR DESCRIPTION
Annotations in positional-only args were not being handled, which resulted in contained names being interpreted as runtime usages:

```py
from __future__ import annotations

from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from typing import List

def func(data: List[int], /) -> None:
    ...

```
```sh
$ flake8 --select TC004 test.py
test.py:6:1: TC004 Move import 'List' out of type-checking block. Import is used for more than type hinting.
```

Hope I put the test in the correct place, let me know if it's better suited for another file 😅 