### PR TITLE
feat: Replace annotation deletion with attribute write

### DIFF
--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -1,6 +1,7 @@
 import sys
 
-ATTRIBUTE_PROPERTY = '_flake8-type-checking_parent'
+ATTRIBUTE_PROPERTY = '_flake8-type-checking__parent'
+ANNOTATION_PROPERTY = '_flake8-type-checking__is_annotation'
 
 ATTRS_DECORATORS = ['attrs.define', 'attr.define', 'attr.s']
 ATTRS_IMPORTS = {'attrs', 'attr'}


### PR DESCRIPTION
PR changes the plugin behaviour from deleting annotations on node objects, to annotating them with a private property that we later use to ignore annotations in `visit_Name`.

Solves #95
