### PR TITLE
Remove `packaging` dependency

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
         id: cache-venv
         with:
           path: .venv
-          key: ${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}-3
+          key: ${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}-5
       - run: |
           python -m venv .venv
           source .venv/bin/activate
@@ -69,8 +69,10 @@ jobs:
       - run: source .venv/bin/activate && poetry install
       - name: Run tests
         run: |
-          source .venv/bin/activate
           pip install flake8==${{ matrix.flake-version }}
+          pip install -e .
+          flake8 .
+          source .venv/bin/activate
           coverage run -m pytest tests
           coverage xml
           coverage report

--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -1,7 +1,6 @@
 import sys
 
 import flake8
-from packaging.version import Version
 
 ATTRIBUTE_PROPERTY = '_flake8-type-checking__parent'
 ANNOTATION_PROPERTY = '_flake8-type-checking__is_annotation'
@@ -10,7 +9,8 @@ ATTRS_DECORATORS = ['attrs.define', 'attr.define', 'attr.s']
 ATTRS_IMPORTS = {'attrs', 'attr'}
 
 py38 = sys.version_info.major == 3 and sys.version_info.minor == 8
-flake_version_gt_v4 = Version(flake8.__version__).major >= 4
+flake_version_gt_v4 = tuple(int(i) for i in flake8.__version__.split('.')) >= (4, 0, 0)
+
 
 # Error codes
 TC001 = "TC001 Move application import '{module}' into a type-checking block"

--- a/poetry.lock
+++ b/poetry.lock
@@ -95,7 +95,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "distlib"
-version = "0.3.4"
+version = "0.3.5"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -558,8 +558,8 @@ decorator = [
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
 ]
 distlib = [
-    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
-    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+    {file = "distlib-0.3.5-py2.py3-none-any.whl", hash = "sha256:b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c"},
+    {file = "distlib-0.3.5.tar.gz", hash = "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe"},
 ]
 executing = [
     {file = "executing-0.8.3-py2.py3-none-any.whl", hash = "sha256:d1eef132db1b83649a3905ca6dd8897f71ac6f8cac79a7e58a1a09cf137546c9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'flake8-type-checking'
-version = "2.0.5"
+version = "2.0.6"
 description = 'A flake8 plugin for managing type-checking imports & forward references'
 homepage = 'https://github.com/snok'
 repository = 'https://github.com/snok/flake8-type-checking'


### PR DESCRIPTION
PR removes packaging in favour of a tuple comparison. We need to know whether the installed flake8 version is 4 or above, and this should hopefully do the trick without requiring any external dependencies.

The PR also adds a `flake8` call in the test workflow, so we can discover these types of issues before a new version is released in the future.

Solves #111 