### PR TITLE
Add `TC006` rule for string literal types in `typing.cast()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ And depending on which error code range you've opted into, it will tell you
 | TC002 | Move third-party import into a type-checking block                                 |
 | TC003 | Move built-in import into a type-checking block                                    |
 | TC004 | Move import out of type-checking block. Import is used for more than type hinting. |
-| TC005 | Empty type-checking block                                                          |
+| TC005 | Found empty type-checking block                                                    |
 
 ## Choosing how to handle forward references
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ And depending on which error code range you've opted into, it will tell you
 
 ## Error codes
 
-| Code   | Description                                                                        |
-|--------|------------------------------------------------------------------------------------|
+| Code  | Description                                                                        |
+|-------|------------------------------------------------------------------------------------|
 | TC001 | Move application import into a type-checking block                                 |
 | TC002 | Move third-party import into a type-checking block                                 |
 | TC003 | Move built-in import into a type-checking block                                    |
@@ -80,17 +80,17 @@ They represent two different ways of solving the same problem, so please only ch
 `TC100` and `TC101` manage forward references by taking advantage of
 [postponed evaluation of annotations](https://www.python.org/dev/peps/pep-0563/).
 
-| Code   | Description                                         |
-|--------|-----------------------------------------------------|
+| Code  | Description                                         |
+|-------|-----------------------------------------------------|
 | TC100 | Add 'from \_\_future\_\_ import annotations' import |
-| TC101 | Annotation does not need to be a string literal |
+| TC101 | Annotation does not need to be a string literal     |
 
 `TC200` and `TC201` manage forward references using [string literals](https://www.python.org/dev/peps/pep-0484/#forward-references).
 
-| Code   | Description                                         |
-|--------|-----------------------------------------------------|
-| TC200 | Annotation needs to be made into a string literal |
-| TC201 | Annotation does not need to be a string literal |
+| Code  | Description                                         |
+|-------|-----------------------------------------------------|
+| TC200 | Annotation needs to be made into a string literal   |
+| TC201 | Annotation does not need to be a string literal     |
 
 ## Enabling error ranges
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ And depending on which error code range you've opted into, it will tell you
 | TC003 | Move built-in import into a type-checking block                                    |
 | TC004 | Move import out of type-checking block. Import is used for more than type hinting. |
 | TC005 | Found empty type-checking block                                                    |
+| TC006 | Annotation in typing.cast() should be a string literal                             |
 
 ## Choosing how to handle forward references
 

--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -18,6 +18,7 @@ TC002 = "TC002 Move third-party import '{module}' into a type-checking block"
 TC003 = "TC003 Move built-in import '{module}' into a type-checking block"
 TC004 = "TC004 Move import '{module}' out of type-checking block. Import is used for more than type hinting."
 TC005 = 'TC005 Found empty type-checking block'
+TC006 = "TC006 Annotation '{annotation}' in typing.cast() should be a string literal"
 TC100 = "TC100 Add 'from __future__ import annotations' import"
 TC101 = "TC101 Annotation '{annotation}' does not need to be a string literal"
 TC200 = "TC200 Annotation '{annotation}' needs to be made into a string literal"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "astor"
+version = "0.8.1"
+description = "Read/rewrite/write Python ASTs"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[[package]]
 name = "asttokens"
 version = "2.0.5"
 description = "Annotate AST trees with source code positions"
@@ -37,9 +45,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope-interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
@@ -172,7 +180,6 @@ pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
 pickleshare = "*"
 prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
 pygments = ">=2.4.0"
-setuptools = ">=18.5"
 stack-data = "*"
 traitlets = ">=5"
 
@@ -230,9 +237,6 @@ description = "Node.js virtual environment builder"
 category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
-
-[package.dependencies]
-setuptools = "*"
 
 [[package]]
 name = "packaging"
@@ -297,8 +301,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
@@ -431,19 +435,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "setuptools"
-version = "63.2.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-reredirects", "sphinxcontrib-towncrier", "furo"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-enabler (>=1.3)", "pytest-perf", "mock", "flake8-2020", "virtualenv (>=13.0.0)", "wheel", "pip (>=19.1)", "jaraco.envs (>=2.2)", "pytest-xdist", "jaraco.path (>=3.2.0)", "build", "filelock (>=3.4.0)", "pip-run (>=8.8)", "ini2toml[lite] (>=0.9)", "tomli-w (>=1.0.0)", "pytest-black (>=0.3.7)", "pytest-cov", "pytest-mypy (>=0.9.1)"]
-testing-integration = ["pytest", "pytest-xdist", "pytest-enabler", "virtualenv (>=13.0.0)", "tomli", "wheel", "jaraco.path (>=3.2.0)", "jaraco.envs (>=2.2)", "build", "filelock (>=3.4.0)"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -465,7 +456,7 @@ executing = "*"
 pure-eval = "*"
 
 [package.extras]
-tests = ["cython", "littleutils", "pygments", "typeguard", "pytest"]
+tests = ["pytest", "typeguard", "pygments", "littleutils", "cython"]
 
 [[package]]
 name = "toml"
@@ -522,12 +513,16 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = '^3.8'
-content-hash = "a3f2571bee8ae3b8280ec89335d7d4073ae19c52a4939777399c93c8a37955e0"
+content-hash = "85a0d028bab256d5da23149c83e8fce6285582290c8af5ed42cf075661e19d98"
 
 [metadata.files]
 appnope = [
     {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
+]
+astor = [
+    {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
+    {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
 ]
 asttokens = [
     {file = "asttokens-2.0.5-py2.py3-none-any.whl", hash = "sha256:0844691e88552595a6f4a4281a9f7f79b8dd45ca4ccea82e5e05b4bbdb76705c"},
@@ -749,10 +744,6 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
-]
-setuptools = [
-    {file = "setuptools-63.2.0-py3-none-any.whl", hash = "sha256:0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16"},
-    {file = "setuptools-63.2.0.tar.gz", hash = "sha256:c04b44a57a6265fe34a4a444e965884716d34bae963119a76353434d6f18e450"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = '^3.8'
 flake8 = '*'
+astor = {python = "<3.9", version = "*"}
 classify-imports = '*'
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_tc006.py
+++ b/tests/test_tc006.py
@@ -1,0 +1,126 @@
+"""
+This file tests the TC006 error:
+
+    >> Annotation in typing.cast() should be a string literal
+
+Types passed to typing.cast() are only ever used by type checkers, never at
+runtime. Despite this, constructing complex types at runtime can have a very
+significant overhead in hot paths. This can be avoided by quoting the type so
+that it isn't resolved at runtime.
+"""
+import textwrap
+
+import pytest
+
+from flake8_type_checking.constants import TC006
+from tests.conftest import _get_error
+
+examples = [
+    # No error
+    ('', set()),
+    # Simple type unquoted
+    (
+        textwrap.dedent(
+            """
+    from typing import cast
+
+    cast(int, 3.0)
+    """
+        ),
+        {'4:5 ' + TC006.format(annotation='int')},
+    ),
+    # Complex type unquoted
+    (
+        textwrap.dedent(
+            """
+    from typing import cast
+
+    cast(list[tuple[bool | float | int | str]], 3.0)
+    """
+        ),
+        {'4:5 ' + TC006.format(annotation='list[tuple[bool | float | int | str]]')},
+    ),
+    # Complex type unquoted using Union
+    (
+        textwrap.dedent(
+            """
+    from typing import Union, cast
+
+    cast(list[tuple[Union[bool, float, int, str]]], 3.0)
+    """
+        ),
+        {'4:5 ' + TC006.format(annotation='list[tuple[Union[bool, float, int, str]]]')},
+    ),
+    # Simple type quoted
+    (
+        textwrap.dedent(
+            """
+    from typing import cast
+
+    cast("int", 3.0)
+    """
+        ),
+        set(),
+    ),
+    # Complex type quoted
+    (
+        textwrap.dedent(
+            """
+    from typing import cast
+
+    cast("list[tuple[bool | float | int | str]]", 3.0)
+    """
+        ),
+        set(),
+    ),
+    # Complex type quoted using Union
+    (
+        textwrap.dedent(
+            """
+    from typing import Union, cast
+
+    cast("list[tuple[Union[bool, float, int, str]]]", 3.0)
+    """
+        ),
+        set(),
+    ),
+    # Call aliased function
+    (
+        textwrap.dedent(
+            """
+    from typing import cast as typecast
+
+    typecast(int, 3.0)
+    """
+        ),
+        {'4:9 ' + TC006.format(annotation='int')},
+    ),
+    # Call function from module
+    (
+        textwrap.dedent(
+            """
+    import typing
+
+    typing.cast(int, 3.0)
+    """
+        ),
+        {'4:12 ' + TC006.format(annotation='int')},
+    ),
+    # Call function from aliased module
+    (
+        textwrap.dedent(
+            """
+    import typing as t
+
+    t.cast(int, 3.0)
+    """
+        ),
+        {'4:7 ' + TC006.format(annotation='int')},
+    ),
+    # TODO: What about importing typing.cast() from another module, e.g. a compat module?
+]
+
+
+@pytest.mark.parametrize(('example', 'expected'), examples)
+def test_TC006_errors(example, expected):
+    assert _get_error(example, error_code_filter='TC006') == expected


### PR DESCRIPTION
Closes #114.