### PR TITLE
fix: only raise TC101 for `str` literals

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -697,7 +697,7 @@ class ImportVisitor(DunderAllMixin, AttrsMixin, FastAPIMixin, PydanticMixin, ast
         elif isinstance(node, (ast.Tuple, ast.List)):
             for n in node.elts:
                 self.add_annotation(n)
-        elif isinstance(node, ast.Constant) and node.value is not None:
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
             # Register annotation value
             setattr(node, ANNOTATION_PROPERTY, True)
             self.wrapped_annotations.append((node.lineno, node.col_offset, node.value))

--- a/tests/test_tc101.py
+++ b/tests/test_tc101.py
@@ -119,6 +119,16 @@ examples = [
         ),
         {'4:21 ' + TC101.format(annotation='X')},
     ),
+    (
+        textwrap.dedent(
+            '''
+        from typing import Annotated
+
+        x: Annotated[int, 42]
+        '''
+        ),
+        set(),
+    ),
 ]
 
 


### PR DESCRIPTION
This PR changes the code related to the TC101 check to only show errors if there's a `str` literal/constant, not any other type.

There are valid use-cases for literals that don't represent types in annotation subscripts, especially with the introduction of `typing.Annotated`, like `x: Annotated[int, 42]` or generally custom types with `__class_getitem__`.

Adding on to this, I suppose `Annotated[int, "stuff"]` should technically also be allowed, but it's not possible to generally differentiate between contexts where a string literal is meant to represent a type (e.g. `Dict[str, "int"]`), and where it doesn't (e.g. `Annotated[str, "int"]`), without hardcoding specific generic types.
As such, this is by far not a perfect solution, but it should get a bit closer :)

For context, this first appeared here:
https://github.com/DisnakeDev/disnake/blob/dd1fb9e4cbfd5974bf4e2ddf001aecc7b6443478/examples/slash_commands/param.py#L76-L78
```py
./examples/slash_commands/param.py:76:29: TC101 Annotation '1' does not need to be a string literal
./examples/slash_commands/param.py:76:32: TC101 Annotation '10' does not need to be a string literal
./examples/slash_commands/param.py:77:35: TC101 Annotation '0' does not need to be a string literal
./examples/slash_commands/param.py:78:30: TC101 Annotation '0' does not need to be a string literal
./examples/slash_commands/param.py:78:33: TC101 Annotation '1.0' does not need to be a string literal
```