### PR TITLE
fix: avoid early return in `used_type_checking_imports`

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -920,6 +920,7 @@ class TypingOnlyImportsChecker:
 
                 # .. or whether there is another duplicate import inside the function scope
                 # (if the use is in a function scope)
+                use_in_function = False
                 if use.lineno in self.visitor.function_ranges:
                     for i in range(
                         self.visitor.function_ranges[use.lineno]['start'],
@@ -929,9 +930,11 @@ class TypingOnlyImportsChecker:
                             i in self.visitor.function_scope_imports
                             and import_name in self.visitor.function_scope_imports[i]['imports']
                         ):
-                            return
+                            use_in_function = True
+                            break
 
-                yield _import.lineno, 0, TC004.format(module=import_name), None
+                if not use_in_function:
+                    yield _import.lineno, 0, TC004.format(module=import_name), None
 
     def empty_type_checking_blocks(self) -> Flake8Generator:
         """TC005."""


### PR DESCRIPTION
This PR prevents false negatives for TC004, which were caused by `used_type_checking_imports` returning immediately on the first function-scoped import usage, and therefore not warning about TC004 errors that would have followed.

I don't think this can't be reproduced/tested reliably, as it depends on the order in which the `type_checking_block_imports` set is iterated over, and AST node hashes arbitrarily change which results in different iteration orders over subsequent flake8 runs.

### Reproduction
```py
from __future__ import annotations
from typing import TYPE_CHECKING


if TYPE_CHECKING:
    from datetime import datetime
    from base64 import b64encode


# runtime usage of `b64encode`, should emit TC004 for the import above
x = b64encode("")


def f() -> datetime:
    # function scope import of `datetime`, special-cased by `used_type_checking_imports`
    from datetime import datetime
    return datetime.utcnow()

```

```sh
$ flake8 test.py
test.py:7:1: TC004 Move import 'b64encode' out of type-checking block. Import is used for more than type hinting.
$ flake8 test.py
test.py:7:1: TC004 Move import 'b64encode' out of type-checking block. Import is used for more than type hinting.
$ flake8 test.py
$ flake8 test.py
$ flake8 test.py
$ flake8 test.py
$ flake8 test.py
test.py:7:1: TC004 Move import 'b64encode' out of type-checking block. Import is used for more than type hinting.
$ flake8 test.py
test.py:7:1: TC004 Move import 'b64encode' out of type-checking block. Import is used for more than type hinting.
$ flake8 test.py
$ flake8 test.py
test.py:7:1: TC004 Move import 'b64encode' out of type-checking block. Import is used for more than type hinting.
```