### PR TITLE
feat: Support `@attrs.frozen` and `@attrs.mutable`

### DIFF
--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -5,7 +5,15 @@ import flake8
 ATTRIBUTE_PROPERTY = '_flake8-type-checking__parent'
 ANNOTATION_PROPERTY = '_flake8-type-checking__is_annotation'
 
-ATTRS_DECORATORS = ['attrs.define', 'attr.define', 'attr.s']
+ATTRS_DECORATORS = [
+    'attrs.define',
+    'attrs.frozen',
+    'attrs.mutable',
+    'attr.define',
+    'attr.frozen',
+    'attr.mutable',
+    'attr.s',
+]
 ATTRS_IMPORTS = {'attrs', 'attr'}
 
 py38 = sys.version_info.major == 3 and sys.version_info.minor == 8

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -17,6 +17,8 @@ from tests.conftest import _get_error
     ('imp', 'dec'),
     [
         ('import attrs', '@attrs.define'),
+        ('import attrs', '@attrs.frozen'),
+        ('import attrs', '@attrs.mutable'),
         ('import attr', '@attr.s(auto_attribs=True)'),
         ('import attr', '@attr.define'),
     ],
@@ -50,8 +52,12 @@ def test_attrs_model(imp, dec):
     ('imp', 'dec', 'expected'),
     [
         ('import attrs', '@attrs.define', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attrs', '@attrs.frozen', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attrs', '@attrs.mutable', {'4:0 ' + TC003.format(module='decimal.Context')}),
         ('import attr', '@attr.s(auto_attribs=True)', {'4:0 ' + TC003.format(module='decimal.Context')}),
         ('import attr', '@attr.define', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attr', '@attr.frozen', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attr', '@attr.mutable', {'4:0 ' + TC003.format(module='decimal.Context')}),
     ],
 )
 def test_complex_attrs_model(imp, dec, expected):
@@ -84,8 +90,12 @@ def test_complex_attrs_model(imp, dec, expected):
     ('imp', 'dec', 'expected'),
     [
         ('from attrs import define', '@define', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('from attrs import frozen', '@frozen', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('from attrs import mutable', '@mutable', {'4:0 ' + TC003.format(module='decimal.Context')}),
         ('from attr import s', '@s(auto_attribs=True)', {'4:0 ' + TC003.format(module='decimal.Context')}),
         ('from attr import define', '@define', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('from attr import frozen', '@frozen', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('from attr import mutable', '@mutable', {'4:0 ' + TC003.format(module='decimal.Context')}),
     ],
 )
 def test_complex_attrs_model_direct_import(imp, dec, expected):
@@ -118,13 +128,19 @@ def test_complex_attrs_model_direct_import(imp, dec, expected):
     ('imp', 'dec', 'expected'),
     [
         ('from attrs import define as asdfg', '@asdfg', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('from attrs import frozen as asdfg', '@asdfg', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('from attrs import mutable as asdfg', '@asdfg', {'4:0 ' + TC003.format(module='decimal.Context')}),
         (
             'from attr import s as ghdjfg',
             '@ghdjfg(auto_attribs=True)',
             {'4:0 ' + TC003.format(module='decimal.Context')},
         ),
         ('import attr as ghdjfg', '@ghdjfg.define', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attr as ghdjfg', '@ghdjfg.frozen', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attr as ghdjfg', '@ghdjfg.mutable', {'4:0 ' + TC003.format(module='decimal.Context')}),
         ('import attr.define as adasdfg', '@adasdfg', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attr.frozen as adasdfg', '@adasdfg', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attr.mutable as adasdfg', '@adasdfg', {'4:0 ' + TC003.format(module='decimal.Context')}),
     ],
 )
 def test_complex_attrs_model_as_import(imp, dec, expected):
@@ -159,6 +175,8 @@ def test_complex_attrs_model_as_import(imp, dec, expected):
     ('imp', 'dec', 'expected'),
     [
         ('from attr import define', '@define(slots=False)', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('from attr import frozen', '@frozen(slots=False)', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('from attr import mutable', '@mutable(slots=False)', {'4:0 ' + TC003.format(module='decimal.Context')}),
         ('from attr import define', '@define(frozen=True)', {'4:0 ' + TC003.format(module='decimal.Context')}),
         (
             'from attr import define',
@@ -166,6 +184,8 @@ def test_complex_attrs_model_as_import(imp, dec, expected):
             {'4:0 ' + TC003.format(module='decimal.Context')},
         ),
         ('import attr', '@attr.define(slots=False, frozen=True)', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attr', '@attr.frozen(slots=False)', {'4:0 ' + TC003.format(module='decimal.Context')}),
+        ('import attr', '@attr.mutable(slots=False)', {'4:0 ' + TC003.format(module='decimal.Context')}),
     ],
 )
 def test_complex_attrs_model_slots_frozen(imp, dec, expected):


### PR DESCRIPTION
The `attrs` package has two additional decorators that are aliases for `@attrs.define` which should be included:

- `attrs.mutable()` is an alias for `attrs.define()`
- `attrs.frozen()` is an alias for `define(frozen=True)`

See https://www.attrs.org/en/stable/names.html#tl-dr