### PR TITLE
chore: remove upper bound from Python version specifier

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -532,8 +532,8 @@ python-versions = "*"
 
 [metadata]
 lock-version = "1.1"
-python-versions = '^3.8'
-content-hash = "63c77d9c4d7357ff62fbbb303b174349ae4c0aa793516a747afd6d3b93087880"
+python-versions = '>=3.8'
+content-hash = "acfa124d358c796daf1cdd69f1ff6f0c97948f0b4566fe0bac9625968627961e"
 
 [metadata.files]
 appnope = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 "Releases" = "https://github.com/snok/flake8-type-checking/releases"
 
 [tool.poetry.dependencies]
-python = '^3.8'
+python = '>=3.8'
 flake8 = '*'
 astor = {python = "<3.9", version = "*"}
 classify-imports = '*'


### PR DESCRIPTION
I've removed the upper bound of the Python version specifier in `pyproject.toml`, i.e. I've replaced the version specifier `^` by `>=`.

Capping the Python version (e.g. `<4`) is a bad practice.

* https://github.com/pypa/packaging.python.org/pull/850
* https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special
* https://discuss.python.org/t/requires-python-upper-limits/12663