### PR TITLE
Allow customization of import classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,36 @@ imports that *can* be moved.
 type-checking-strict = true  # default false
 ```
 
+### Customizing import classification
+
+The plugin categorizes imports into application, third-party, and builtin
+based on whether they can be found in the standard library or the application path.
+
+If your application treats directories other than the root directory as
+root-level import directories, specify them here to classify imports in
+those directories as application modules instead of third-party.
+
+If you still wish to include the root directory (`.`), you must also specify it.
+
+- **setting name**: `type-checking-application-directories`
+- **type**: `list`
+
+```ini
+[flake8]
+type-checking-application-directories = .,libs  # default "."
+```
+
+If you wish to further override the classification behavior by marking certain
+modules as application modules, regardless of where they reside, specify them here.
+
+- **setting name**: `type-checking-unclassifiable-application-modules`
+- **type**: `list`
+
+```ini
+[flake]
+type-checking-unclassifiable-application-modules = os,math  # default []
+```
+
 ### Pydantic support
 
 If you use Pydantic models in your code, you should enable Pydantic support.

--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -48,6 +48,20 @@ class Plugin:
             default=False,
             help='Flag individual imports rather than looking at the module.',
         )
+        option_manager.add_option(
+            '--type-checking-application-directories',
+            comma_separated_list=True,
+            parse_from_config=True,
+            default=None,
+            help='Directories relative to the current directory to be considered application source roots.',
+        )
+        option_manager.add_option(
+            '--type-checking-unclassifiable-application-modules',
+            comma_separated_list=True,
+            parse_from_config=True,
+            default=None,
+            help='Modules to always consider application modules.',
+        )
 
         # Third-party library options
         option_manager.add_option(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,8 @@ def _get_error(example: str, *, error_code_filter: Optional[str] = None, **kwarg
         # defaults
         mock_options.extended_default_select = []
         mock_options.enable_extensions = []
+        mock_options.type_checking_application_directories = None
+        mock_options.type_checking_unclassifiable_application_modules = None
         mock_options.type_checking_pydantic_enabled = False
         mock_options.type_checking_exempt_modules = []
         mock_options.type_checking_fastapi_enabled = False

--- a/tests/test_tc001_to_tc003.py
+++ b/tests/test_tc001_to_tc003.py
@@ -216,6 +216,27 @@ def test_TC001_errors(example: str, expected: set[str]) -> None:
     assert _get_error(example, error_code_filter='TC001') == expected
 
 
+@pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests(mod, TC003))
+def test_no_application_directories(example, expected):
+    """Without the current directory marked as an application directory, it will be seen as a builtin"""
+    assert _get_error(example, error_code_filter='TC003', type_checking_application_directories=[]) == expected
+
+
+@pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('conftest', TC001))
+def test_extra_application_directories(example, expected):
+    """Module should be seen as an application module if its directory is specified"""
+    assert _get_error(example, error_code_filter='TC001', type_checking_application_directories=['tests']) == expected
+
+
+@pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('pandas', TC001))
+def test_unclassifiable_application_modules_third_party(example, expected):
+    """Third-party application module should be seen as application module if specified"""
+    assert (
+        _get_error(example, error_code_filter='TC001', type_checking_unclassifiable_application_modules=['pandas'])
+        == expected
+    )
+
+
 @pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('pandas', TC002))
 def test_TC002_errors(example, expected):
     assert _get_error(example, error_code_filter='TC002') == expected
@@ -224,3 +245,12 @@ def test_TC002_errors(example, expected):
 @pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('os', TC003))
 def test_TC003_errors(example, expected):
     assert _get_error(example, error_code_filter='TC003') == expected
+
+
+@pytest.mark.parametrize(('example', 'expected'), get_tc_001_to_003_tests('os', TC001))
+def test_unclassifiable_application_modules_builtin(example, expected):
+    """Builtin application module should be seen as application module if specified"""
+    assert (
+        _get_error(example, error_code_filter='TC001', type_checking_unclassifiable_application_modules=['os'])
+        == expected
+    )


### PR DESCRIPTION
This commit adds two plugin settings that provide support for the [`classify-imports` settings](https://github.com/asottile/classify-imports/blob/8d0e115b4b95dbe6bcfafbaae2d1323ba7fbdfbf/classify_imports.py#L49-L51) that allow additional modules to be classified as application imports.

In my project, there is a `libs` directory that is always added to the `PYTHONPATH`, so a module located at `~/<project_root>/libs/foobar/code.py` can be imported as
```python
from foobar import code
```
without specifying `libs.`

By default, `classify-imports` sees no `foobar` directory inside `<project_root>` and assumes it is a third-party module. This change allows specifying
```ini
type-checking-application-directories = libs
```
or
```ini
type-checking-unclassifiable-application-modules = foobar
```
and making the import classified as an application module.

This is a non-breaking change; without any additional configuration, everything behaves as it did before.