### PR TITLE
Remove fix for "double namespace" imports

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -651,19 +651,7 @@ class ImportVisitor(DunderAllMixin, AttrsMixin, FastAPIMixin, PydanticMixin, ast
             return node
 
         if hasattr(node, ATTRIBUTE_PROPERTY):
-            # When importing modules like 'import urllib.parse'
-            # and calling 'urllib.parse.urlencode(some_string)',
-            # we only receive 'urllib' here as the node.id, but can
-            # construct 'urllib.parse.urlencode' by using the attribute property.
-            # Alas, the import in this case would only match 'urllib.parse', so for
-            # this case, we add two uses in these cases where the link-length is gt 2
-            full_name = f'{node.id}.{getattr(node, ATTRIBUTE_PROPERTY)}'
-            split_names = full_name.split('.')
-            if len(split_names) > 2:
-                self.uses[full_name] = node
-                self.uses['.'.join(split_names[:-1])] = node
-            else:
-                self.uses[full_name] = node
+            self.uses[f'{node.id}.{getattr(node, ATTRIBUTE_PROPERTY)}'] = node
 
         self.uses[node.id] = node
         return node


### PR DESCRIPTION
In 54dde2e59955318937a3d21f88b34deb9bc74a4f a fix was implemented for "double namespace" imports, where a module is imported like
```python
import urllib.parse
```
and then referenced like
```python
urllib.parse.urlencode(some_string)
```

The issue causing this behavior was actually the handling of "nested" attributes originally added in 77f9c3a2712592fd12fe10e6bfa00c8a4b89b9a6, and since removed e4362ecc0c66ed16ca541f386d4b651800240959. By performing the removal in e4362ecc0c66ed16ca541f386d4b651800240959, the test suite passes without the "double namespace" fix.

Removing this code also removes two lines that would never actually be called when running the code, and therefore could not have any test coverage.