### PR TITLE
fix: TC201 should never emit for classes defined in-file

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -1139,7 +1139,7 @@ class TypingOnlyImportsChecker:
                     break
             else:
                 for class_name in self.visitor.class_names:
-                    if class_name == annotation:
+                    if class_name in annotation:
                         break
                 else:
                     yield lineno, col_offset, TC201.format(annotation=annotation), None

--- a/tests/test_tc201.py
+++ b/tests/test_tc201.py
@@ -76,6 +76,17 @@ examples = [
         '''),
         set(),
     ),
+    (
+        # avoid false positive for annotations that make
+        # use of a newly defined class
+        textwrap.dedent('''
+        class Foo(Protocol):
+            pass
+
+        x: 'Foo | None'
+        '''),
+        set(),
+    ),
 ]
 
 


### PR DESCRIPTION
I found another false positive for TC201 when a wrapped annotation is more complex than directly referring to a defined class name.

I changed the condition for `class_name` to match the one for `import_name`. This should be more consistent.