### PR TITLE
Fix: extract names from ForwardRef

### DIFF
--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -4,6 +4,7 @@ import flake8
 
 ATTRIBUTE_PROPERTY = '_flake8-type-checking__parent'
 ANNOTATION_PROPERTY = '_flake8-type-checking__is_annotation'
+TOP_LEVEL_PROPERTY = '_flake8-type-checking__is_top_level'
 
 ATTRS_DECORATORS = [
     'attrs.define',

--- a/tests/test_tc101.py
+++ b/tests/test_tc101.py
@@ -2,6 +2,7 @@
 File tests TC101:
     Annotation is wrapped in unnecessary quotes
 """
+import sys
 import textwrap
 
 import pytest
@@ -113,7 +114,37 @@ examples = [
         '''),
         set(),
     ),
+    # Make sure we didn't introduce any regressions while solving #167
+    # since we started to treat the RHS sort of like an annotation for
+    # some of the use-cases
+    (
+        textwrap.dedent('''
+        from __future__ import annotations
+        if TYPE_CHECKING:
+            from foo import Foo
+
+        x: TypeAlias = 'Foo'
+        '''),
+        set(),
+    ),
 ]
+
+if sys.version_info >= (3, 12):
+    examples.append(
+        (
+            # Make sure we didn't introduce any regressions while solving #167
+            # using new type alias syntax
+            # TODO: Make sure we actually need to wrap Foo if we use future
+            textwrap.dedent('''
+            from __future__ import annotations
+            if TYPE_CHECKING:
+                from foo import Foo
+
+            type x = 'Foo'
+            '''),
+            set(),
+        )
+    )
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)

--- a/tests/test_tc200.py
+++ b/tests/test_tc200.py
@@ -2,6 +2,7 @@
 File tests TC200:
     Annotation should be wrapped in quotes
 """
+import sys
 import textwrap
 
 import pytest
@@ -102,12 +103,44 @@ examples = [
         '''),
         {
             '9:5 ' + TC200.format(annotation='TypeAlias'),
+            '9:17 ' + TC200.format(annotation='Sequence'),
             '12:9 ' + TC200.format(annotation='Sequence'),
             '15:9 ' + TC200.format(annotation='Sequence'),
             '18:9 ' + TC200.format(annotation='Sequence'),
         },
     ),
+    # RHS on an explicit TypeAlias should also emit a TC200
+    (
+        textwrap.dedent('''
+        from typing import TypeAlias
+
+        if TYPE_CHECKING:
+            from collections.abc import Sequence
+
+        Foo: TypeAlias = Sequence[int]
+        '''),
+        {
+            '7:17 ' + TC200.format(annotation='Sequence'),
+        },
+    ),
 ]
+
+if sys.version_info >= (3, 12):
+    # RHS on an explicit TypeAlias should also emit a TC200
+    # new type alias syntax
+    examples.append(
+        (
+            textwrap.dedent('''
+            if TYPE_CHECKING:
+                from collections.abc import Sequence
+
+            type Foo = Sequence[int]
+            '''),
+            {
+                '5:17 ' + TC200.format(annotation='Sequence'),
+            },
+        )
+    )
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)

--- a/tests/test_tc200.py
+++ b/tests/test_tc200.py
@@ -137,7 +137,7 @@ if sys.version_info >= (3, 12):
             type Foo = Sequence[int]
             '''),
             {
-                '5:17 ' + TC200.format(annotation='Sequence'),
+                '5:11 ' + TC200.format(annotation='Sequence'),
             },
         )
     )

--- a/tests/test_tc201.py
+++ b/tests/test_tc201.py
@@ -2,6 +2,7 @@
 File tests TC201:
     Annotation is wrapped in unnecessary quotes
 """
+import sys
 import textwrap
 
 import pytest
@@ -87,7 +88,78 @@ examples = [
         '''),
         set(),
     ),
+    (
+        # Regression test for Issue #168
+        textwrap.dedent('''
+        if TYPE_CHECKING:
+            Foo = str | int
+            Bar: TypeAlias = Foo | None
+            T = TypeVar('T')
+            Ts = TypeVarTuple('Ts')
+            P = ParamSpec('P')
+
+        x: 'Foo | None'
+        y: 'Bar | None'
+        Z: TypeAlias = 'Foo'
+
+        def foo(a: 'T', *args: Unpack['Ts']) -> None:
+            pass
+
+        def bar(*args: 'P.args', **kwargs: 'P.kwargs') -> None:
+            pass
+        '''),
+        set(),
+    ),
+    (
+        # Inverse regression test for Issue #168
+        # The declarations are inside a Protocol so they should not
+        # count towards declarations inside a type checking block
+        textwrap.dedent('''
+        if TYPE_CHECKING:
+            class X(Protocol):
+                Foo = str | int
+                Bar: TypeAlias = Foo | None
+                T = TypeVar('T')
+                Ts = TypeVarTuple('Ts')
+                P = ParamSpec('P')
+
+        x: 'Foo | None'
+        y: 'Bar | None'
+        Z: TypeAlias = 'Foo'
+
+        def foo(a: 'T', *args: Unpack['Ts']) -> None:
+            pass
+
+        def bar(*args: 'P.args', **kwargs: 'P.kwargs') -> None:
+            pass
+        '''),
+        {
+            '10:3 ' + TC201.format(annotation='Foo | None'),
+            '11:3 ' + TC201.format(annotation='Bar | None'),
+            '12:15 ' + TC201.format(annotation='Foo'),
+            '14:11 ' + TC201.format(annotation='T'),
+            '14:30 ' + TC201.format(annotation='Ts'),
+            '17:15 ' + TC201.format(annotation='P.args'),
+            '17:35 ' + TC201.format(annotation='P.kwargs'),
+        },
+    ),
 ]
+
+if sys.version_info >= (3, 12):
+    examples.append(
+        (
+            # Regression test for Issue #168
+            # using new type alias syntax
+            textwrap.dedent('''
+            if TYPE_CHECKING:
+                type Foo = str | int
+
+            x: 'Foo | None'
+            type Z = 'Foo'
+            '''),
+            set(),
+        )
+    )
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)


### PR DESCRIPTION
This is a draft because it's based on #170 due to some of the refactors and may yet need to change a bit more and thus should not be merged until #170 is merged.

This extracts all the names from the wrapped annotations and stores them in a set alongside the annotation, this is a little bit more reliable than the substring check we have been doing thus far and also works more reliably for determining when F401 should be sufficient for `unused_imports`.