### PR TITLE
fix: Avoid potentially harmful TC201 false positives

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -1280,7 +1280,7 @@ class TypingOnlyImportsChecker:
             # give up immediately if the annotation contains square brackets, because
             # we can't know if subscripting the type at runtime is safe without inspecting
             # the type's source code.
-            if '[' in item.annotation:
+            if '[' in item.annotation or '.' in item.annotation:
                 continue
 
             # See comment in futures_excess_quotes

--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -7,7 +7,7 @@ ATTRIBUTE_PROPERTY = '_flake8-type-checking__parent'
 ANNOTATION_PROPERTY = '_flake8-type-checking__is_annotation'
 GLOBAL_PROPERTY = '_flake8-type-checking__is_global'
 
-NAME_RE = re.compile(r'(?<![\'"])\b[A-Za-z_]\w*(?![\'"])')
+NAME_RE = re.compile(r'(?<![\'".])\b[A-Za-z_]\w*(?![\'"])')
 
 ATTRS_DECORATORS = [
     'attrs.define',

--- a/tests/test_name_extraction.py
+++ b/tests/test_name_extraction.py
@@ -21,6 +21,9 @@ examples = [
     # even when it's formatted badly
     ('*Ts|_T&P', ['Ts', '_T', 'P']),
     ('Union[Dict[str, Any], Literal["Foo", "Bar"], _T]', ['Union', 'Dict', 'str', 'Any', 'Literal', '_T']),
+    # for attribute access only everything up to the first dot should count
+    # this matches the behavior of add_annotation
+    ('datetime.date | os.path.sep', ['datetime', 'os']),
 ]
 
 

--- a/tests/test_tc201.py
+++ b/tests/test_tc201.py
@@ -113,6 +113,10 @@ examples = [
         # Inverse regression test for Issue #168
         # The declarations are inside a Protocol so they should not
         # count towards declarations inside a type checking block
+        # This used to raise errors for P.args and P.kwargs and
+        # ideally it still would, but it would require more complex
+        # logic in order to avoid false positives, so for now we
+        # put up with the false negatives here
         textwrap.dedent('''
         if TYPE_CHECKING:
             class X(Protocol):
@@ -137,9 +141,16 @@ examples = [
             '11:3 ' + TC201.format(annotation='Bar | None'),
             '14:11 ' + TC201.format(annotation='T'),
             '14:30 ' + TC201.format(annotation='Ts'),
-            '17:15 ' + TC201.format(annotation='P.args'),
-            '17:35 ' + TC201.format(annotation='P.kwargs'),
         },
+    ),
+    (
+        # Regression test for type checking only module attributes
+        textwrap.dedent('''
+        import lxml.etree
+
+        foo: 'lxml.etree._Element'
+        '''),
+        set(),
     ),
 ]
 


### PR DESCRIPTION
Things are looking really good now with v2.5.0, I only had to add about two or three `noqa` comments on a medium sized project, compared to the hundreds I would've had to add before, nevertheless the `noqa` I had to add were TC201 errors that would cause a runtime exception, so I think it's better we treat this like subscripts.

Specifically the following is one such case:
```python
from lxml import etree

element: 'etree._Element'   # TC201
```
`_Element` only exists in the stubs, so unwrapping that annotation would result in a runtime error.

I've adjusted the RegEx for name extraction to only include the LHS on attribute access, this matches what `add_annotation` does, although I'm not quite sure what it's doing right now is correct, since for `uses` we also record `lhs.rhs`, presumably to handle and match imports like `import os.path` correctly. But if we wanted to clean that up I'd prefer opening a new issue for it and to tackle it some other time.

In addition to checking for `[` in wrapped annotations I now also check for `.` and skip that annotation in TC201.