### PR TITLE
Adds TC009 for type checking declarations used at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,17 @@ And depending on which error code range you've opted into, it will tell you
 
 ## Error codes
 
-| Code  | Description                                                                        |
-|-------|------------------------------------------------------------------------------------|
-| TC001 | Move application import into a type-checking block                                 |
-| TC002 | Move third-party import into a type-checking block                                 |
-| TC003 | Move built-in import into a type-checking block                                    |
-| TC004 | Move import out of type-checking block. Import is used for more than type hinting. |
-| TC005 | Found empty type-checking block                                                    |
-| TC006 | Annotation in typing.cast() should be a string literal                             |
-| TC007 | Type alias needs to be made into a string literal                                  |
-| TC008 | Type alias does not need to be a string literal                                    |
+| Code  | Description                                                                               |
+|-------|-------------------------------------------------------------------------------------------|
+| TC001 | Move application import into a type-checking block                                        |
+| TC002 | Move third-party import into a type-checking block                                        |
+| TC003 | Move built-in import into a type-checking block                                           |
+| TC004 | Move import out of type-checking block. Import is used for more than type hinting.        |
+| TC005 | Found empty type-checking block                                                           |
+| TC006 | Annotation in typing.cast() should be a string literal                                    |
+| TC007 | Type alias needs to be made into a string literal                                         |
+| TC008 | Type alias does not need to be a string literal                                           |
+| TC009 | Move declaration out of type-checking block. Variable is used for more than type hinting. |
 
 ## Choosing how to handle forward references
 

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -1543,8 +1543,15 @@ class TypingOnlyImportsChecker:
                 else:
                     lookup_from = use
 
-                if scope.lookup(symbol.name, lookup_from):
+                if scope.lookup(symbol.name, lookup_from, runtime_only=True):
                     # the symbol is available at runtime so we're fine
+                    continue
+                elif scope.lookup(symbol.name, lookup_from, runtime_only=False) is not symbol:
+                    # we are being shadowed so no need to emit an error, we can emit an error
+                    # for the shadowed name instead, this relies more heavily on giving us the
+                    # closest match when looking up symbols, so we may sometimes get this wrong
+                    # in cases where the symbol has been redefined within the same scope. But
+                    # the most important case is nested scopes, so this is probably fine.
                     continue
 
                 if symbol.type == 'import':

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -1319,9 +1319,8 @@ class ImportVisitor(DunderAllMixin, AttrsMixin, FastAPIMixin, PydanticMixin, ast
         a little lax here, since there are no annotations inside comprehensions
         anyways.
         """
-        in_type_checking_block = self.in_type_checking_block(node.lineno, node.col_offset)
-
         assert self.active_context is not None
+        in_type_checking_block = self.in_type_checking_block(self.active_context.lineno, self.active_context.col_offset)
         for name in getattr(node.target, 'elts', [node.target]):
             if not hasattr(name, 'id'):
                 continue

--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -1,3 +1,4 @@
+import builtins
 import re
 import sys
 
@@ -5,7 +6,7 @@ import flake8
 
 ATTRIBUTE_PROPERTY = '_flake8-type-checking__parent'
 ANNOTATION_PROPERTY = '_flake8-type-checking__is_annotation'
-GLOBAL_PROPERTY = '_flake8-type-checking__is_global'
+DUNDER_ALL_PROPERTY = '_flake8-type-checking__in__all__'
 
 NAME_RE = re.compile(r'(?<![\'".])\b[A-Za-z_]\w*(?![\'"])')
 
@@ -23,6 +24,8 @@ ATTRS_IMPORTS = {'attrs', 'attr'}
 py38 = sys.version_info.major == 3 and sys.version_info.minor == 8
 flake_version_gt_v4 = tuple(int(i) for i in flake8.__version__.split('.')) >= (4, 0, 0)
 
+# Based off of what pyflakes does
+builtin_names = set(dir(builtins)) | {'__file__', '__builtins__', '__annotations__', 'WindowsError'}
 
 # Error codes
 TC001 = "TC001 Move application import '{module}' into a type-checking block"

--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -33,6 +33,7 @@ TC005 = 'TC005 Found empty type-checking block'
 TC006 = "TC006 Annotation '{annotation}' in typing.cast() should be a string literal"
 TC007 = "TC007 Type alias '{alias}' needs to be made into a string literal"
 TC008 = "TC008 Type alias '{alias}' does not need to be a string literal"
+TC009 = "TC009 Move declaration '{name}' out of type-checking block. Variable is used for more than type hinting."
 TC100 = "TC100 Add 'from __future__ import annotations' import"
 TC101 = "TC101 Annotation '{annotation}' does not need to be a string literal"
 TC200 = "TC200 Annotation '{annotation}' needs to be made into a string literal"

--- a/flake8_type_checking/types.py
+++ b/flake8_type_checking/types.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     import ast
+    import sys
     from typing import Any, Generator, Optional, Protocol, Tuple, TypedDict, Union
 
     class FunctionRangesDict(TypedDict):
@@ -13,6 +14,10 @@ if TYPE_CHECKING:
     class FunctionScopeNamesDict(TypedDict):
         names: list[str]
 
+    if sys.version_info >= (3, 12):
+        Declaration = Union[ast.ClassDef, ast.AnnAssign, ast.Assign, ast.TypeAlias]
+    else:
+        Declaration = Union[ast.ClassDef, ast.AnnAssign, ast.Assign]
     Import = Union[ast.Import, ast.ImportFrom]
     Flake8Generator = Generator[Tuple[int, int, str, Any], None, None]
 

--- a/flake8_type_checking/types.py
+++ b/flake8_type_checking/types.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from typing import Any, Generator, Optional, Protocol, Tuple, Union
 
     Function = Union[ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda]
+    Comprehension = Union[ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp]
     Import = Union[ast.Import, ast.ImportFrom]
     Flake8Generator = Generator[Tuple[int, int, str, Any], None, None]
 

--- a/flake8_type_checking/types.py
+++ b/flake8_type_checking/types.py
@@ -4,26 +4,24 @@ from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     import ast
-    import sys
-    from typing import Any, Generator, Optional, Protocol, Tuple, TypedDict, Union
+    from typing import Any, Generator, Optional, Protocol, Tuple, Union
 
-    class FunctionRangesDict(TypedDict):
-        start: int
-        end: int
-
-    class FunctionScopeNamesDict(TypedDict):
-        names: list[str]
-
-    if sys.version_info >= (3, 12):
-        Declaration = Union[ast.ClassDef, ast.AnnAssign, ast.Assign, ast.TypeAlias]
-    else:
-        Declaration = Union[ast.ClassDef, ast.AnnAssign, ast.Assign]
+    Function = Union[ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda]
     Import = Union[ast.Import, ast.ImportFrom]
     Flake8Generator = Generator[Tuple[int, int, str, Any], None, None]
 
     class Name(Protocol):
         asname: Optional[str]
         name: str
+
+    class HasPosition(Protocol):
+        @property
+        def lineno(self) -> int:
+            pass
+
+        @property
+        def col_offset(self) -> int:
+            pass
 
 
 ImportTypeValue = Literal['APPLICATION', 'THIRD_PARTY', 'BUILTIN', 'FUTURE']

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ exclude =
     __pycache__,
 per-file-ignores =
     flake8_type_checking/checker.py:SIM114
-    flake8_type_checking/types.py:D101
+    flake8_type_checking/types.py:D
     tests/**.py:D103,D205,D400,D102,D101
 
 [mypy]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ def _get_error(example: str, *, error_code_filter: Optional[str] = None, **kwarg
         mock_options.select = [error_code_filter]
         mock_options.extend_select = None
         # defaults
+        mock_options.builtins = []
         mock_options.extended_default_select = []
         mock_options.enable_extensions = []
         mock_options.type_checking_pydantic_enabled = False

--- a/tests/test_tc004.py
+++ b/tests/test_tc004.py
@@ -154,6 +154,33 @@ examples = [
         """),
         set(),
     ),
+    # Inverse Regression test for #131
+    # handle scopes correctly, so we should get an error for the imports
+    # in the inner scopes, but not one for the outer scope.
+    (
+        textwrap.dedent("""
+        if TYPE_CHECKING:
+            from a import Foo
+
+        def foo():
+            if TYPE_CHECKING:
+                from b import Foo
+
+            bar: Foo = Foo()
+            return bar
+
+        class X:
+            if TYPE_CHECKING:
+                from b import Foo
+
+            bar: Foo = Foo()
+
+        """),
+        {
+            '7:0 ' + TC004.format(module='Foo'),
+            '14:0 ' + TC004.format(module='Foo'),
+        },
+    ),
     # Some more complex scope cases where we shouldn't report a
     # runtime use of a typing only symbol, because it is shadowed
     # by an inline definition. We use five different symbols

--- a/tests/test_tc004.py
+++ b/tests/test_tc004.py
@@ -127,22 +127,6 @@ examples = [
     """),
         set(),
     ),
-    # regression test for #131
-    # a common pattern for inheriting from generics that aren't runtime subscriptable
-    (
-        textwrap.dedent("""
-        from wtforms import Field
-
-        if TYPE_CHECKING:
-            BaseField = Field[int]
-        else:
-            BaseField = Field
-
-        class IntegerField(BaseField):
-            pass
-    """),
-        set(),
-    ),
     # Regression test for #131
     # handle scopes correctly
     (

--- a/tests/test_tc004.py
+++ b/tests/test_tc004.py
@@ -156,7 +156,7 @@ examples = [
             else:
                 Foo = object
 
-            bar: Foo
+            bar: Foo = Foo()
             return bar
 
         class X:
@@ -165,7 +165,7 @@ examples = [
             else:
                 Foo = object
 
-            bar: Foo
+            bar: Foo = Foo()
 
     """),
         set(),

--- a/tests/test_tc004.py
+++ b/tests/test_tc004.py
@@ -127,6 +127,49 @@ examples = [
     """),
         set(),
     ),
+    # regression test for #131
+    # a common pattern for inheriting from generics that aren't runtime subscriptable
+    (
+        textwrap.dedent("""
+        from wtforms import Field
+
+        if TYPE_CHECKING:
+            BaseField = Field[int]
+        else:
+            BaseField = Field
+
+        class IntegerField(BaseField):
+            pass
+    """),
+        set(),
+    ),
+    # Regression test for #131
+    # handle scopes correctly
+    (
+        textwrap.dedent("""
+        if TYPE_CHECKING:
+            from a import Foo
+
+        def foo():
+            if TYPE_CHECKING:
+                from b import Foo
+            else:
+                Foo = object
+
+            bar: Foo
+            return bar
+
+        class X:
+            if TYPE_CHECKING:
+                from b import Foo
+            else:
+                Foo = object
+
+            bar: Foo
+
+    """),
+        set(),
+    ),
 ]
 
 

--- a/tests/test_tc004.py
+++ b/tests/test_tc004.py
@@ -170,24 +170,9 @@ examples = [
         """),
         set(),
     ),
-    # some more complex scope cases where we shouldn't report a
+    # Some more complex scope cases where we shouldn't report a
     # runtime use of a typing only symbol, because it is shadowed
-    # by an inline definition
-    (
-        textwrap.dedent("""
-        if TYPE_CHECKING:
-            from a import foo
-
-        (foo for foo in x)
-        [foo for y in x if (foo := y)]
-        {{foo for y in x for foo in y}}
-        {{foo: bar for y, foo in x for bar in y}}
-        x = foo if (foo := y) else None
-
-        """),
-        set(),
-    ),
-    # Inverse test for complex cases, we use five different symbols
+    # by an inline definition. We use five different symbols
     # since comprehension scopes will probably leak their iterator
     # variables in the future, just like regular loops, due to
     # comprehension inlining. So we currently treat definitions inside
@@ -198,9 +183,24 @@ examples = [
     (
         textwrap.dedent("""
         if TYPE_CHECKING:
-            from foo import u, w, x, y, z
+            from foo import v, w, x, y, z
 
-        (u(a) for a in foo)
+        (v for v in foo)
+        [w for bar in foo if (w := bar)]
+        {{x for bar in foo for x in bar}}
+        {{y: baz for y, bar in foo for baz in y}}
+        foo = z if (z := bar) else None
+
+        """),
+        set(),
+    ),
+    # Inverse test for complex cases
+    (
+        textwrap.dedent("""
+        if TYPE_CHECKING:
+            from foo import v, w, x, y, z
+
+        (v(a) for a in foo)
         [w(a) for a in foo]
         {{x(a) for a in foo}}
         {{a: y for a in foo}}
@@ -208,7 +208,7 @@ examples = [
 
         """),
         {
-            '3:0 ' + TC004.format(module='u'),
+            '3:0 ' + TC004.format(module='v'),
             '3:0 ' + TC004.format(module='w'),
             '3:0 ' + TC004.format(module='x'),
             '3:0 ' + TC004.format(module='y'),

--- a/tests/test_tc008.py
+++ b/tests/test_tc008.py
@@ -51,15 +51,14 @@ examples = [
         set(),
     ),
     (
-        # avoid false positive for annotations that make
-        # use of a newly defined class
+        # this used to yield false negatives but works now, yay
         textwrap.dedent('''
         class Foo(Protocol):
             pass
 
         x: TypeAlias = 'Foo | None'
         '''),
-        set(),
+        {'5:15 ' + TC008.format(alias='Foo | None')},
     ),
     (
         # Regression test for Issue #168
@@ -72,19 +71,19 @@ examples = [
         set(),
     ),
     (
-        # Inverse regression test for Issue #168
-        # The declarations are inside a Protocol so they should not
-        # count towards declarations inside a type checking block
+        # Regression test for Issue #168
+        # The runtime declaration are inside a Protocol so they should not
+        # affect the outcome
         textwrap.dedent('''
         if TYPE_CHECKING:
+            Foo: TypeAlias = str | int
+        else:
             class X(Protocol):
                 Foo: str | int
 
         Bar: TypeAlias = 'Foo'
         '''),
-        {
-            '6:17 ' + TC008.format(alias='Foo'),
-        },
+        set(),
     ),
 ]
 

--- a/tests/test_tc009.py
+++ b/tests/test_tc009.py
@@ -18,92 +18,92 @@ examples = [
     # Used in file
     (
         textwrap.dedent("""
-    from typing import TYPE_CHECKING
+        from typing import TYPE_CHECKING
 
-    if TYPE_CHECKING:
-        datetime = Any
+        if TYPE_CHECKING:
+            datetime = Any
 
-    x = datetime
-    """),
+        x = datetime
+        """),
         {'5:4 ' + TC009.format(name='datetime')},
     ),
     # Used in function
     (
         textwrap.dedent("""
-    from typing import TYPE_CHECKING
+        from typing import TYPE_CHECKING
 
-    if TYPE_CHECKING:
-        class date: ...
+        if TYPE_CHECKING:
+            class date: ...
 
-    def example():
-        return date()
-    """),
+        def example():
+            return date()
+        """),
         {'5:4 ' + TC009.format(name='date')},
     ),
     # Used, but only used inside the type checking block
     (
         textwrap.dedent("""
-    if TYPE_CHECKING:
-        class date: ...
+        if TYPE_CHECKING:
+            class date: ...
 
-        CustomType = date
-    """),
+            CustomType = date
+        """),
         set(),
     ),
     # Used for typing only
     (
         textwrap.dedent("""
-    if TYPE_CHECKING:
-        class date: ...
+        if TYPE_CHECKING:
+            class date: ...
 
-    def example(*args: date, **kwargs: date):
-        return
+        def example(*args: date, **kwargs: date):
+            return
 
-    my_type: Type[date] | date
-    """),
+        my_type: Type[date] | date
+        """),
         set(),
     ),
     (
         textwrap.dedent("""
-    from __future__ import annotations
+        from __future__ import annotations
 
-    from typing import TYPE_CHECKING
+        from typing import TYPE_CHECKING
 
-    if TYPE_CHECKING:
-        class AsyncIterator: ...
+        if TYPE_CHECKING:
+            class AsyncIterator: ...
 
 
-    class Example:
+        class Example:
 
-        async def example(self) -> AsyncIterator[list[str]]:
-            yield 0
-    """),
+            async def example(self) -> AsyncIterator[list[str]]:
+                yield 0
+        """),
         set(),
     ),
     (
         textwrap.dedent("""
-    from typing import TYPE_CHECKING
-    from weakref import WeakKeyDictionary
+        from typing import TYPE_CHECKING
+        from weakref import WeakKeyDictionary
 
-    if TYPE_CHECKING:
-        Any = str
+        if TYPE_CHECKING:
+            Any = str
 
 
-    d = WeakKeyDictionary["Any", "Any"]()
-    """),
+        d = WeakKeyDictionary["Any", "Any"]()
+        """),
         set(),
     ),
     (
         textwrap.dedent("""
-    if TYPE_CHECKING:
-        a = int
-        b: TypeAlias = str
-        class c(Protocol): ...
-        class d(TypedDict): ...
+        if TYPE_CHECKING:
+            a = int
+            b: TypeAlias = str
+            class c(Protocol): ...
+            class d(TypedDict): ...
 
-    def test_function(a, /, b, *, c, **d):
-        print(a, b, c, d)
-    """),
+        def test_function(a, /, b, *, c, **d):
+            print(a, b, c, d)
+        """),
         set(),
     ),
     # Regression test for #131
@@ -131,8 +131,38 @@ examples = [
 
             bar: Foo = Foo()
 
-    """),
+        """),
         set(),
+    ),
+    # regression test for #131
+    # a common pattern for inheriting from generics that aren't runtime subscriptable
+    (
+        textwrap.dedent("""
+        from wtforms import Field
+
+        if TYPE_CHECKING:
+            BaseField = Field[int]
+        else:
+            BaseField = Field
+
+        class IntegerField(BaseField):
+            pass
+        """),
+        set(),
+    ),
+    # inverse regression test for #131
+    # here we forgot the else so it will complain about BaseField
+    (
+        textwrap.dedent("""
+        from wtforms import Field
+
+        if TYPE_CHECKING:
+            BaseField = Field[int]
+
+        class IntegerField(BaseField):
+            pass
+        """),
+        {'5:4 ' + TC009.format(name='BaseField')},
     ),
 ]
 

--- a/tests/test_tc009.py
+++ b/tests/test_tc009.py
@@ -1,0 +1,138 @@
+"""
+This file tests the TC009 error:
+
+    >> Move declaration out of type-checking block. Variable is used for more than type hinting.
+
+"""
+import sys
+import textwrap
+
+import pytest
+
+from flake8_type_checking.constants import TC009
+from tests.conftest import _get_error
+
+examples = [
+    # No error
+    ('', set()),
+    # Used in file
+    (
+        textwrap.dedent("""
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        datetime = Any
+
+    x = datetime
+    """),
+        {'5:4 ' + TC009.format(name='datetime')},
+    ),
+    # Used in function
+    (
+        textwrap.dedent("""
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        class date: ...
+
+    def example():
+        return date()
+    """),
+        {'5:4 ' + TC009.format(name='date')},
+    ),
+    # Used, but only used inside the type checking block
+    (
+        textwrap.dedent("""
+    if TYPE_CHECKING:
+        class date: ...
+
+        CustomType = date
+    """),
+        set(),
+    ),
+    # Used for typing only
+    (
+        textwrap.dedent("""
+    if TYPE_CHECKING:
+        class date: ...
+
+    def example(*args: date, **kwargs: date):
+        return
+
+    my_type: Type[date] | date
+    """),
+        set(),
+    ),
+    (
+        textwrap.dedent("""
+    from __future__ import annotations
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        class AsyncIterator: ...
+
+
+    class Example:
+
+        async def example(self) -> AsyncIterator[list[str]]:
+            yield 0
+    """),
+        set(),
+    ),
+    (
+        textwrap.dedent("""
+    from typing import TYPE_CHECKING
+    from weakref import WeakKeyDictionary
+
+    if TYPE_CHECKING:
+        Any = str
+
+
+    d = WeakKeyDictionary["Any", "Any"]()
+    """),
+        set(),
+    ),
+    (
+        textwrap.dedent("""
+    if TYPE_CHECKING:
+        a = int
+        b: TypeAlias = str
+        class c(Protocol): ...
+        class d(TypedDict): ...
+
+    def test_function(a, /, b, *, c, **d):
+        print(a, b, c, d)
+    """),
+        set(),
+    ),
+]
+
+if sys.version_info >= (3, 12):
+    examples.append(
+        (
+            textwrap.dedent("""
+            if TYPE_CHECKING:
+                type Foo = int
+
+            x = Foo
+            """),
+            {'3:4 ' + TC009.format(name='Foo')},
+        )
+    )
+    examples.append(
+        (
+            textwrap.dedent("""
+            if TYPE_CHECKING:
+                type Foo = int
+
+            x: Foo
+            """),
+            set(),
+        )
+    )
+
+
+@pytest.mark.parametrize(('example', 'expected'), examples)
+def test_TC009_errors(example, expected):
+    assert _get_error(example, error_code_filter='TC009') == expected

--- a/tests/test_tc009.py
+++ b/tests/test_tc009.py
@@ -119,7 +119,7 @@ examples = [
             else:
                 Foo = object
 
-            bar: Foo
+            bar: Foo = Foo()
             return bar
 
         class X:
@@ -129,7 +129,7 @@ examples = [
             else:
                 Foo = object
 
-            bar: Foo
+            bar: Foo = Foo()
 
     """),
         set(),

--- a/tests/test_tc009.py
+++ b/tests/test_tc009.py
@@ -106,6 +106,34 @@ examples = [
     """),
         set(),
     ),
+    # Regression test for #131
+    # handle scopes correctly
+    (
+        textwrap.dedent("""
+        if TYPE_CHECKING:
+            Foo: something
+
+        def foo():
+            if TYPE_CHECKING:
+                Foo: something_else
+            else:
+                Foo = object
+
+            bar: Foo
+            return bar
+
+        class X:
+            if TYPE_CHECKING:
+                class Foo(Protocol):
+                    pass
+            else:
+                Foo = object
+
+            bar: Foo
+
+    """),
+        set(),
+    ),
 ]
 
 if sys.version_info >= (3, 12):

--- a/tests/test_tc100.py
+++ b/tests/test_tc100.py
@@ -16,12 +16,18 @@ from tests.conftest import _get_error, mod
 examples = [
     # No errors
     ('', set()),
+    # Unused declaration
     ('if TYPE_CHECKING:\n\tx = 2', set()),
+    # Used declaration
+    ('if TYPE_CHECKING:\n\tx = 2\ny = x + 2', set()),
+    ('if TYPE_CHECKING:\n\tT = TypeVar("T")\nx: T\ny = T', set()),
+    # Declaration used only in annotation
+    ('if TYPE_CHECKING:\n\tT = TypeVar("T")\nx: T', {'1:0 ' + TC100}),
     # Unused import
-    ('if TYPE_CHECKING:\n\tfrom typing import Dict', {'1:0 ' + TC100}),
-    ('if TYPE_CHECKING:\n\tfrom typing import Dict, Any', {'1:0 ' + TC100}),
-    (f'if TYPE_CHECKING:\n\timport {mod}', {'1:0 ' + TC100}),
-    (f'if TYPE_CHECKING:\n\tfrom {mod} import constants', {'1:0 ' + TC100}),
+    ('if TYPE_CHECKING:\n\tfrom typing import Dict', set()),
+    ('if TYPE_CHECKING:\n\tfrom typing import Dict, Any', set()),
+    (f'if TYPE_CHECKING:\n\timport {mod}', set()),
+    (f'if TYPE_CHECKING:\n\tfrom {mod} import constants', set()),
     # Used imports
     ('if TYPE_CHECKING:\n\tfrom typing import Dict\nx = Dict', set()),
     ('if TYPE_CHECKING:\n\tfrom typing import Dict, Any\nx, y = Dict, Any', set()),
@@ -35,9 +41,6 @@ examples = [
     ('if TYPE_CHECKING:\n\tfrom typing import Dict\ndef example(x: Dict[str, int] = {}):\n\tpass', {'1:0 ' + TC100}),
     # Import used for returns
     ('if TYPE_CHECKING:\n\tfrom typing import Dict\ndef example() -> Dict[str, int]:\n\tpass', {'1:0 ' + TC100}),
-    # Probably not much point in adding many more test cases, as the logic for TC100
-    # is not dependent on the type of annotation assignments; it's purely concerned with
-    # whether an ast.Import or ast.ImportFrom exists within a type checking block
 ]
 
 

--- a/tests/test_tc100.py
+++ b/tests/test_tc100.py
@@ -7,6 +7,8 @@ The idea is that we should raise one of these errors if a file contains any type
 
 One thing to note: futures imports should always be at the top of a file, so we only need to check one line.
 """
+import sys
+import textwrap
 
 import pytest
 
@@ -42,6 +44,25 @@ examples = [
     # Import used for returns
     ('if TYPE_CHECKING:\n\tfrom typing import Dict\ndef example() -> Dict[str, int]:\n\tpass', {'1:0 ' + TC100}),
 ]
+
+if sys.version_info >= (3, 12):
+    # PEP695 tests
+    examples += [
+        (
+            textwrap.dedent("""
+            if TYPE_CHECKING:
+                from .types import T
+
+            def foo[T](a: T) -> T: ...
+
+            type Foo[T] = T | None
+
+            class Bar[T](Sequence[T]):
+                x: T
+            """),
+            set(),
+        )
+    ]
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)

--- a/tests/test_tc101.py
+++ b/tests/test_tc101.py
@@ -132,21 +132,23 @@ examples = [
 ]
 
 if sys.version_info >= (3, 12):
-    examples.append(
+    # PEP695 tests
+    examples += [
         (
-            # Make sure we didn't introduce any regressions while solving #167
-            # using new type alias syntax
-            # TODO: Make sure we actually need to wrap Foo if we use future
-            textwrap.dedent('''
-            from __future__ import annotations
-            if TYPE_CHECKING:
-                from foo import Foo
+            textwrap.dedent("""
+            def foo[T](a: 'T') -> 'T':
+                pass
 
-            type x = 'Foo'
-            '''),
-            set(),
+            class Bar[T](Set['T']):
+                x: 'T'
+            """),
+            {
+                '2:14 ' + TC101.format(annotation='T'),
+                '2:22 ' + TC101.format(annotation='T'),
+                '6:7 ' + TC101.format(annotation='T'),
+            },
         )
-    )
+    ]
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)

--- a/tests/test_tc101.py
+++ b/tests/test_tc101.py
@@ -16,7 +16,8 @@ examples = [
     ("x: 'int'", {'1:3 ' + TC101.format(annotation='int')}),
     ("from __future__ import annotations\nx: 'int'", {'2:3 ' + TC101.format(annotation='int')}),
     ("if TYPE_CHECKING:\n\timport y\nx: 'y'", set()),
-    ("x: 'Dict[int]'", {'1:3 ' + TC101.format(annotation='Dict[int]')}),
+    # this used to return an error, but it's prone to false positives
+    ("x: 'dict[int]'", set()),
     ("if TYPE_CHECKING:\n\tfrom typing import Dict\nx: 'Dict[int]'", set()),
     ("if TYPE_CHECKING:\n\tFoo: TypeAlias = Any\nx: 'Foo'", set()),
     # Basic AnnAssign with type-checking block and exact match

--- a/tests/test_tc101.py
+++ b/tests/test_tc101.py
@@ -18,6 +18,7 @@ examples = [
     ("if TYPE_CHECKING:\n\timport y\nx: 'y'", set()),
     ("x: 'Dict[int]'", {'1:3 ' + TC101.format(annotation='Dict[int]')}),
     ("if TYPE_CHECKING:\n\tfrom typing import Dict\nx: 'Dict[int]'", set()),
+    ("if TYPE_CHECKING:\n\tFoo: TypeAlias = Any\nx: 'Foo'", set()),
     # Basic AnnAssign with type-checking block and exact match
     (
         "from __future__ import annotations\nif TYPE_CHECKING:\n\tfrom typing import Dict\nx: 'Dict'",

--- a/tests/test_tc200.py
+++ b/tests/test_tc200.py
@@ -2,6 +2,7 @@
 File tests TC200:
     Annotation should be wrapped in quotes
 """
+import sys
 import textwrap
 
 import pytest
@@ -125,6 +126,25 @@ examples = [
         },
     ),
 ]
+
+if sys.version_info >= (3, 12):
+    # PEP695 tests
+    examples += [
+        (
+            textwrap.dedent("""
+            if TYPE_CHECKING:
+                from .types import T
+
+            def foo[T](a: T) -> T: ...
+
+            type Foo[T] = T | None
+
+            class Bar[T](Sequence[T]):
+                x: T
+            """),
+            set(),
+        )
+    ]
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)

--- a/tests/test_tc200.py
+++ b/tests/test_tc200.py
@@ -15,8 +15,19 @@ examples = [
     ('x: int', set()),
     ('x: "int"', set()),
     ('from typing import Dict\nx: Dict[int]', set()),
+    # Unused import/declaration
+    ('if TYPE_CHECKING:\n\tfrom typing import Dict', set()),
+    ('if TYPE_CHECKING:\n\tx = 2', set()),
+    # Used import/declaration
+    ('if TYPE_CHECKING:\n\tfrom typing import Dict\nx: Dict = Dict()', set()),
+    ('if TYPE_CHECKING:\n\tx = 2\ny = x + 2', set()),
+    ('if TYPE_CHECKING:\n\tT = TypeVar("T")\nx: T\ny = T', set()),
+    # Import/Declaration used only in annotation
     ('if TYPE_CHECKING:\n\tfrom typing import Dict\nx: Dict', {'3:3 ' + TC200.format(annotation='Dict')}),
+    ('if TYPE_CHECKING:\n\tT = TypeVar("T")\nx: T', {'3:3 ' + TC200.format(annotation='T')}),
     ("if TYPE_CHECKING:\n\tfrom typing import Dict\nx: 'Dict'", set()),
+    ('if TYPE_CHECKING:\n\tFoo: TypeAlias = Any\nx: Foo', {'3:3 ' + TC200.format(annotation='Foo')}),
+    ("if TYPE_CHECKING:\n\tFoo: TypeAlias = Any\nx: 'Foo'", set()),
     ("if TYPE_CHECKING:\n\tfrom typing import Dict as d\nx: 'd[int]'", set()),
     ('if TYPE_CHECKING:\n\tfrom typing import Dict\nx: Dict[int]', {'3:3 ' + TC200.format(annotation='Dict')}),
     ('if TYPE_CHECKING:\n\timport something\nx: something', {'3:3 ' + TC200.format(annotation='something')}),

--- a/tests/test_tc201.py
+++ b/tests/test_tc201.py
@@ -2,6 +2,7 @@
 File tests TC201:
     Annotation is wrapped in unnecessary quotes
 """
+import sys
 import textwrap
 
 import pytest
@@ -154,6 +155,25 @@ examples = [
         set(),
     ),
 ]
+
+if sys.version_info >= (3, 12):
+    # PEP695 tests
+    examples += [
+        (
+            textwrap.dedent("""
+            def foo[T](a: 'T') -> 'T':
+                pass
+
+            class Bar[T]:
+                x: 'T'
+            """),
+            {
+                '2:14 ' + TC201.format(annotation='T'),
+                '2:22 ' + TC201.format(annotation='T'),
+                '6:7 ' + TC201.format(annotation='T'),
+            },
+        )
+    ]
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)


### PR DESCRIPTION
Extends TC100/TC200 to deal with type checking declarations
Avoids a couple of false positives in TC100/TC101
Avoids contradicting TC004/TC009 errors vs. TC100/TC200 errors
Closes #131
Closes #172 


This passes some of the fixes I've already applied to TC200/TC201 along to TC100/TC101 but also improves handling of type checking declarations for TC100/TC200.

In order to avoid introducing false positives/misleading errors I've also added TC009 to be the equivalent of TC004 for type checking declarations.