### PR TITLE
fix(injector): resolve issue with Injector requires all annotations

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -547,6 +547,8 @@ class InjectorMixin:
             for argument in (item for item in path if hasattr(item, 'annotation')):
                 if argument.annotation:
                     yield argument.annotation
+        if node.args.kwarg and hasattr(node.args.kwarg, 'annotation') and node.args.kwarg.annotation:
+            yield node.args.kwarg.annotation
 
 
 class FastAPIMixin:

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -544,8 +544,9 @@ class InjectorMixin:
 
     def _list_annotations(self, node: Union[AsyncFunctionDef, FunctionDef]) -> Iterator[ast.AST]:
         for path in [node.args.args, node.args.kwonlyargs]:
-            for argument in (item for item in path if hasattr(item, 'annotation') and item.annotation):
-                yield argument.annotation
+            for argument in (item for item in path if hasattr(item, 'annotation')):
+                if argument.annotation:
+                    yield argument.annotation
 
 
 class FastAPIMixin:

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -543,12 +543,12 @@ class InjectorMixin:
         return False
 
     def _list_annotations(self, node: Union[AsyncFunctionDef, FunctionDef]) -> Iterator[ast.AST]:
-        for path in [node.args.args, node.args.kwonlyargs]:
-            for argument in (item for item in path if hasattr(item, 'annotation')):
-                if argument.annotation:
-                    yield argument.annotation
-        if node.args.kwarg and hasattr(node.args.kwarg, 'annotation') and node.args.kwarg.annotation:
-            yield node.args.kwarg.annotation
+        for argument in chain(node.args.args, node.args.kwonlyargs, node.args.posonlyargs):
+            if annotation := getattr(argument, 'annotation', None):
+                yield annotation
+        for arg in (node.args.kwarg, node.args.vararg):
+            if arg and (annotation := getattr(arg, 'annotation', None)):
+                yield annotation
 
 
 class FastAPIMixin:

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -50,14 +50,18 @@ def test_injector_option(enabled, expected):
 @pytest.mark.parametrize(
     ('enabled', 'expected'),
     [
-        (True, {'4:0 ' + TC002.format(module='other_dependency.OtherDependency')}),
+        (False, {
+            '2:0 ' + TC002.format(module='injector.Inject'),
+            '3:0 ' + TC002.format(module='services.Service'),
+            '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
+        }),
         (
-            False,
-            {
-                '2:0 ' + TC002.format(module='injector.Inject'),
-                '3:0 ' + TC002.format(module='services.Service'),
-                '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
-            },
+                False,
+                {
+                    '2:0 ' + TC002.format(module='injector.Inject'),
+                    '3:0 ' + TC002.format(module='services.Service'),
+                    '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
+                },
         ),
     ],
 )
@@ -79,14 +83,18 @@ def test_injector_option_only_allows_injected_dependencies(enabled, expected):
 @pytest.mark.parametrize(
     ('enabled', 'expected'),
     [
-        (True, {'4:0 ' + TC002.format(module='other_dependency.OtherDependency')}),
+        (False, {
+            '2:0 ' + TC002.format(module='injector.Inject'),
+            '3:0 ' + TC002.format(module='services.Service'),
+            '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
+        }),
         (
-            False,
-            {
-                '2:0 ' + TC002.format(module='injector.Inject'),
-                '3:0 ' + TC002.format(module='services.Service'),
-                '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
-            },
+                False,
+                {
+                    '2:0 ' + TC002.format(module='injector.Inject'),
+                    '3:0 ' + TC002.format(module='services.Service'),
+                    '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
+                },
         ),
     ],
 )

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -82,6 +82,23 @@ def test_injector_option_only_allows_injector_slices(enabled, expected):
     assert _get_error(example, error_code_filter='TC002', type_checking_injector_enabled=enabled) == expected
 
 
+@pytest.mark.parametrize(('enabled', 'expected'), [(True, set())])
+def test_injector_option_require_injections_under_unpack(enabled, expected):
+    """Whenever an injector option is enabled, injected dependencies should be ignored, even if unpacked."""
+    example = textwrap.dedent("""
+        from typing import Unpack
+
+        from injector import Inject
+        from services import ServiceKwargs
+
+        class X:
+            def __init__(self, service: Inject[Service], **kwargs: Unpack[ServiceKwargs]) -> None:
+                self.service = service
+                self.args = args
+        """)
+    assert _get_error(example, error_code_filter='TC002', type_checking_injector_enabled=enabled) == expected
+
+
 @pytest.mark.parametrize(
     ('enabled', 'expected'),
     [

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -48,20 +48,15 @@ def test_injector_option(enabled, expected):
 
 
 @pytest.mark.parametrize(
-    ('enabled', 'expected'),
+    'enabled',
     [
-        (False, {
-            '2:0 ' + TC002.format(module='injector.Inject'),
-            '3:0 ' + TC002.format(module='services.Service'),
-            '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
-        }),
         (
-                False,
-                {
-                    '2:0 ' + TC002.format(module='injector.Inject'),
-                    '3:0 ' + TC002.format(module='services.Service'),
-                    '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
-                },
+            False,
+            {
+                '2:0 ' + TC002.format(module='injector.Inject'),
+                '3:0 ' + TC002.format(module='services.Service'),
+                '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
+            },
         ),
     ],
 )
@@ -81,20 +76,15 @@ def test_injector_option_only_allows_injected_dependencies(enabled, expected):
 
 
 @pytest.mark.parametrize(
-    ('enabled', 'expected'),
+    'enabled',
     [
-        (False, {
-            '2:0 ' + TC002.format(module='injector.Inject'),
-            '3:0 ' + TC002.format(module='services.Service'),
-            '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
-        }),
         (
-                False,
-                {
-                    '2:0 ' + TC002.format(module='injector.Inject'),
-                    '3:0 ' + TC002.format(module='services.Service'),
-                    '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
-                },
+            False,
+            {
+                '2:0 ' + TC002.format(module='injector.Inject'),
+                '3:0 ' + TC002.format(module='services.Service'),
+                '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
+            },
         ),
     ],
 )

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -47,19 +47,7 @@ def test_injector_option(enabled, expected):
     assert _get_error(example, error_code_filter='TC002', type_checking_injector_enabled=enabled) == expected
 
 
-@pytest.mark.parametrize(
-    'enabled',
-    [
-        (
-            False,
-            {
-                '2:0 ' + TC002.format(module='injector.Inject'),
-                '3:0 ' + TC002.format(module='services.Service'),
-                '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
-            },
-        ),
-    ],
-)
+@pytest.mark.parametrize(('enabled', 'expected'), [(True, set())])
 def test_injector_option_only_allows_injected_dependencies(enabled, expected):
     """Whenever an injector option is enabled, only injected dependencies should be ignored."""
     example = textwrap.dedent('''
@@ -75,19 +63,7 @@ def test_injector_option_only_allows_injected_dependencies(enabled, expected):
     assert _get_error(example, error_code_filter='TC002', type_checking_injector_enabled=enabled) == expected
 
 
-@pytest.mark.parametrize(
-    'enabled',
-    [
-        (
-            False,
-            {
-                '2:0 ' + TC002.format(module='injector.Inject'),
-                '3:0 ' + TC002.format(module='services.Service'),
-                '4:0 ' + TC002.format(module='other_dependency.OtherDependency'),
-            },
-        ),
-    ],
-)
+@pytest.mark.parametrize(('enabled', 'expected'), [(True, set())])
 def test_injector_option_only_allows_injector_slices(enabled, expected):
     """
     Whenever an injector option is enabled, only injected dependencies should be ignored,


### PR DESCRIPTION
injector library requires all annotation of function available in the runtime, not only dependencies under "Inject" annotation.

