### PR TITLE
fix: `typing.Annotated` should be special-cased like `typing.Literal`

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -21,7 +21,6 @@ from flake8_type_checking.constants import (
     ATTRS_DECORATORS,
     ATTRS_IMPORTS,
     BINOP_OPERAND_PROPERTY,
-    NAME_RE,
     TC001,
     TC002,
     TC003,
@@ -310,7 +309,9 @@ class SQLAlchemyAnnotationVisitor(AnnotationVisitor):
 
     def visit_annotation_string(self, node: ast.Constant) -> None:
         """Add all the names in the string to mapped names."""
-        self.mapped_names.update(NAME_RE.findall(node.value))
+        visitor = StringAnnotationVisitor()
+        visitor.parse_and_visit_string_annotation(node.value)
+        self.mapped_names.update(visitor.names)
 
 
 class SQLAlchemyMixin:
@@ -431,10 +432,9 @@ class SQLAlchemyMixin:
             if not annotation.endswith(']'):
                 return
 
-            # if we ever do more sophisticated parsing of text annotations
-            # then we would want to strip the trailing `]` from inner, but
-            # with our simple parsing we don't care
             mapped_name, inner = annotation.split('[', 1)
+            # strip trailing `]` from inner
+            inner = inner[:-1]
             if mapped_name in self.mapped_aliases:
                 # record a use for the name
                 self.uses[mapped_name].append((node, self.current_scope))
@@ -456,7 +456,9 @@ class SQLAlchemyMixin:
             # add all names contained in the inner part of the annotation
             # since this is not as strict as an actual runtime use, we don't
             # care if we record too much here
-            self.mapped_names.update(NAME_RE.findall(inner))
+            visitor = StringAnnotationVisitor()
+            visitor.parse_and_visit_string_annotation(inner)
+            self.mapped_names.update(visitor.names)
             return
 
         # we only need to handle annotations like `Mapped[...]`
@@ -825,6 +827,39 @@ class Scope:
         return parent.lookup(symbol_name, use, runtime_only)
 
 
+class StringAnnotationVisitor(AnnotationVisitor):
+    """Visit a parsed string annotation and collect all the names."""
+
+    def __init__(self) -> None:
+        #: All the names referenced inside the annotation
+        self.names: set[str] = set()
+
+    def parse_and_visit_string_annotation(self, annotation: str) -> None:
+        """Parse and visit the given string as an annotation expression."""
+        try:
+            # in the future this simple approach may fail, because
+            # the quoted subexpression is only valid syntax in the context
+            # of the parent expression, in which case we would have to
+            # do something more clever here
+            module_node = ast.parse(f'_: {annotation}')
+        except Exception:
+            # if we can't parse the annotation we should do nothing
+            return
+
+        ann_assign_node = module_node.body[0]
+        assert isinstance(ann_assign_node, ast.AnnAssign)
+        annotation_node = ann_assign_node.annotation
+        self.visit(annotation_node)
+
+    def visit_annotation_name(self, node: ast.Name) -> None:
+        """Remember all the visited names."""
+        self.names.add(node.id)
+
+    def visit_annotation_string(self, node: ast.Constant) -> None:
+        """Parse and visit nested string annotations."""
+        self.parse_and_visit_string_annotation(node.value)
+
+
 class ImportAnnotationVisitor(AnnotationVisitor):
     """Map all annotations on an AST node."""
 
@@ -878,10 +913,10 @@ class ImportAnnotationVisitor(AnnotationVisitor):
         if getattr(node, BINOP_OPERAND_PROPERTY, False):
             self.invalid_binop_literals.append(node)
         else:
+            visitor = StringAnnotationVisitor()
+            visitor.parse_and_visit_string_annotation(node.value)
             (self.excess_wrapped_annotations if self.never_evaluates else self.wrapped_annotations).append(
-                WrappedAnnotation(
-                    node.lineno, node.col_offset, node.value, set(NAME_RE.findall(node.value)), self.scope, self.type
-                )
+                WrappedAnnotation(node.lineno, node.col_offset, node.value, visitor.names, self.scope, self.type)
             )
 
 

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -96,7 +96,12 @@ class AnnotationVisitor(ABC):
             self.visit(node.value)
         elif isinstance(node, ast.Subscript):
             self.visit(node.value)
-            if getattr(node.value, 'id', '') != 'Literal':
+            if getattr(node.value, 'id', '') == 'Annotated' and isinstance(node.slice, (ast.Tuple, ast.List)):
+                if node.slice.elts:
+                    # only visit the first element
+                    self.visit(node.slice.elts[0])
+                    # TODO: We may want to visit the rest as a soft-runtime use
+            elif getattr(node.value, 'id', '') != 'Literal':
                 self.visit(node.slice)
         elif isinstance(node, (ast.Tuple, ast.List)):
             for n in node.elts:

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -96,10 +96,13 @@ class AnnotationVisitor(ABC):
             self.visit(node.value)
         elif isinstance(node, ast.Subscript):
             self.visit(node.value)
-            if getattr(node.value, 'id', '') == 'Annotated' and isinstance(node.slice, (ast.Tuple, ast.List)):
-                if node.slice.elts:
+            if getattr(node.value, 'id', '') == 'Annotated' and isinstance(
+                (elts_node := node.slice.value if py38 and isinstance(node.slice, Index) else node.slice),
+                (ast.Tuple, ast.List),
+            ):
+                if elts_node.elts:
                     # only visit the first element
-                    self.visit(node.slice.elts[0])
+                    self.visit(elts_node.elts[0])
                     # TODO: We may want to visit the rest as a soft-runtime use
             elif getattr(node.value, 'id', '') != 'Literal':
                 self.visit(node.slice)

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -841,7 +841,7 @@ class StringAnnotationVisitor(AnnotationVisitor):
             # the quoted subexpression is only valid syntax in the context
             # of the parent expression, in which case we would have to
             # do something more clever here
-            module_node = ast.parse(f'_: {annotation}')
+            module_node = ast.parse(f'_: _[{annotation}]')
         except Exception:
             # if we can't parse the annotation we should do nothing
             return
@@ -849,7 +849,8 @@ class StringAnnotationVisitor(AnnotationVisitor):
         ann_assign_node = module_node.body[0]
         assert isinstance(ann_assign_node, ast.AnnAssign)
         annotation_node = ann_assign_node.annotation
-        self.visit(annotation_node)
+        assert isinstance(annotation_node, ast.Subscript)
+        self.visit(annotation_node.slice)
 
     def visit_annotation_name(self, node: ast.Name) -> None:
         """Remember all the visited names."""

--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -1,5 +1,4 @@
 import builtins
-import re
 import sys
 
 import flake8
@@ -7,8 +6,6 @@ import flake8
 ATTRIBUTE_PROPERTY = '_flake8-type-checking__parent'
 ANNOTATION_PROPERTY = '_flake8-type-checking__is_annotation'
 BINOP_OPERAND_PROPERTY = '_flake8-type-checking__is_binop_operand'
-
-NAME_RE = re.compile(r'(?<![\'".])\b[A-Za-z_]\w*(?![\'"])')
 
 ATTRS_DECORATORS = [
     'attrs.define',

--- a/tests/test_name_extraction.py
+++ b/tests/test_name_extraction.py
@@ -1,32 +1,38 @@
+import sys
+
 import pytest
 
-from flake8_type_checking.constants import NAME_RE
+from flake8_type_checking.checker import StringAnnotationVisitor
 
 examples = [
-    ('', []),
-    ('int', ['int']),
-    ('dict[str, int]', ['dict', 'str', 'int']),
+    ('', set()),
+    ('invalid_syntax]', set()),
+    ('int', {'int'}),
+    ('dict[str, int]', {'dict', 'str', 'int'}),
     # make sure literals don't add names for their contents
-    ('Literal["a"]', ['Literal']),
-    ("Literal['a']", ['Literal']),
-    ('Literal[0]', ['Literal']),
-    ('Literal[1.0]', ['Literal']),
-    # booleans are a special case and difficult to reject using a RegEx
-    # for now it seems harmless to include them in the names, but if
-    # we do something more sophisticated with the names we may want to
-    # explicitly remove True/False from the result set
-    ('Literal[True]', ['Literal', 'True']),
-    # try some potentially upcoming syntax
-    ('*Ts | _T & S', ['Ts', '_T', 'S']),
-    # even when it's formatted badly
-    ('*Ts|_T&P', ['Ts', '_T', 'P']),
-    ('Union[Dict[str, Any], Literal["Foo", "Bar"], _T]', ['Union', 'Dict', 'str', 'Any', 'Literal', '_T']),
+    ('Literal["a"]', {'Literal'}),
+    ("Literal['a']", {'Literal'}),
+    ('Literal[0]', {'Literal'}),
+    ('Literal[1.0]', {'Literal'}),
+    ('Literal[True]', {'Literal'}),
+    ('T | S', {'T', 'S'}),
+    ('Union[Dict[str, Any], Literal["Foo", "Bar"], _T]', {'Union', 'Dict', 'str', 'Any', 'Literal', '_T'}),
     # for attribute access only everything up to the first dot should count
     # this matches the behavior of add_annotation
-    ('datetime.date | os.path.sep', ['datetime', 'os']),
+    ('datetime.date | os.path.sep', {'datetime', 'os'}),
+    ('Nested["str"]', {'Nested', 'str'}),
+    ('Annotated[str, validator]', {'Annotated', 'str'}),
+    ('Annotated[str, "bool"]', {'Annotated', 'str'}),
 ]
+
+if sys.version_info >= (3, 11):
+    examples.extend([
+        ('*Ts', {'Ts'}),
+    ])
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)
 def test_name_extraction(example, expected):
-    assert NAME_RE.findall(example) == expected
+    visitor = StringAnnotationVisitor()
+    visitor.parse_and_visit_string_annotation(example)
+    assert visitor.names == expected

--- a/tests/test_tc001_to_tc003.py
+++ b/tests/test_tc001_to_tc003.py
@@ -195,6 +195,26 @@ def get_tc_001_to_003_tests(import_: str, ERROR: str) -> L:
                 '''),
             set(),
         ),
+        (
+            textwrap.dedent(f'''
+                from typing import Annotated
+
+                from {import_} import Depends
+
+                x: Annotated[str, Depends]
+            '''),
+            set(),
+        ),
+        (
+            textwrap.dedent(f'''
+                from typing import Annotated
+
+                from {import_} import Depends
+
+                x: Annotated[str, "Depends"]
+            '''),
+            set(),
+        ),
     ]
 
     return [


### PR DESCRIPTION
This is a partial fix for #192

This is probably not a huge change, since we skipped unexpected nodes within annotations already, so it would mostly get rid of some false positives where a string within `Annotated` happened to match one of the imported symbols and thus being treated as a forward reference incorrectly.

I still need to think about a solution for string annotations and whether or not we should visit the nodes we're currently skipping, maybe we should pass `self` into `AnnotationVisitor` so we can call the `generic_visit` of the outer visitor?