### PR TITLE
refactor: Create a common utility for looking up fully qualified names

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -1194,11 +1194,21 @@ class ImportVisitor(
                 else:
                     self.pydantic_validate_arguments_import_name = name_node.name
 
+            if name_node.name == '*':
+                # don't record * imports
+                continue
+
             exempt = exempt or name_node.name in self.exempt_imports
 
             # Classify and map imports
+            if isinstance(node, ast.ImportFrom):
+                module = f'{node.module}.' if node.module else ''
+                if node.level != 0:
+                    module = '.' * node.level + module
+            else:
+                module = ''
             imp = ImportName(
-                _module=f'{node.module}.' if isinstance(node, ast.ImportFrom) else '',
+                _module=module,
                 _alias=name_node.asname,
                 _name=name_node.name,
                 exempt=exempt,

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -333,7 +333,6 @@ class SQLAlchemyMixin:
         sqlalchemy_mapped_dotted_names: set[str]
         current_scope: Scope
         uses: dict[str, list[tuple[ast.AST, Scope]]]
-        star_import_module_names: set[str]
 
         def in_type_checking_block(self, lineno: int, col_offset: int) -> bool:  # noqa: D102
             ...
@@ -371,19 +370,6 @@ class SQLAlchemyMixin:
                 node_or_name = ann_assign_node.target
             except Exception:
                 return False
-
-        if self.star_import_module_names and isinstance(node_or_name, ast.Name):
-            for dotted_name in self.sqlalchemy_mapped_dotted_names:
-                parts = dotted_name.rsplit('.', 1)
-                if len(parts) != 2:
-                    # Should we not make this a silent error? Or do we perhaps
-                    # even want to allow unqualified names and accept any symbol
-                    # that has the same name?
-                    continue
-
-                module, symbol = parts
-                if symbol == node_or_name.id and module in self.star_import_module_names:
-                    return True
 
         return self.lookup_full_name(node_or_name) in self.sqlalchemy_mapped_dotted_names
 
@@ -936,12 +922,6 @@ class ImportVisitor(
         # then use the import type to yield the error with the appropriate type
         self.imports: dict[str, ImportName] = {}
 
-        #: A set of all the module names that star imported all their symbols
-        # This is used to figure out when a simple qualified name lookup won't
-        # work, so if we want to match a target expression against a full name
-        # we will have to check if the module part is within this set
-        self.star_import_module_names: set[str] = set()
-
         #: List of scopes including all the symbols within
         self.scopes: list[Scope] = []
 
@@ -1051,22 +1031,8 @@ class ImportVisitor(
         # fallback to returning the name as-is
         return '.'.join(parts)
 
-    def match_full_name(self, node: ast.AST, full_name: str) -> bool:
-        """Check if the given target node matches the given fully qualified name."""
-        if self.star_import_module_names and isinstance(node, ast.Name):
-            module, symbol = full_name.rsplit('.', 1)
-            if module in self.star_import_module_names:
-                # for star imports we can only check if the symbol name matches
-                return symbol == node.id
-
-        return self.lookup_full_name(node) == full_name
-
     def is_typing(self, node: ast.AST, symbol: str) -> bool:
-        """Check if the given target node matches the given typing symbol."""
-        if isinstance(node, ast.Name) and self.star_import_module_names & {'typing', 'typing_extensions'}:
-            # for star imports we can only check if the symbol name matches
-            return node.id == symbol
-
+        """Check if the given node matches the given typing symbol."""
         full_name = self.lookup_full_name(node)
         if full_name is None or '.' not in full_name:
             return False
@@ -1249,10 +1215,7 @@ class ImportVisitor(
                     self.pydantic_validate_arguments_import_name = name_node.name
 
             if name_node.name == '*':
-                # Only add the module to the list of star imports
-                assert isinstance(node, ast.ImportFrom)
-                if node.level == 0 and node.module:
-                    self.star_import_module_names.add(node.module)
+                # don't record * imports
                 continue
 
             # Classify and map imports
@@ -1262,7 +1225,6 @@ class ImportVisitor(
                     module = '.' * node.level + module
             else:
                 module = ''
-
             imp = ImportName(
                 _module=module,
                 _alias=name_node.asname,

--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -334,20 +334,14 @@ class SQLAlchemyMixin:
         current_scope: Scope
         uses: dict[str, list[tuple[ast.AST, Scope]]]
 
-        def visit(self, node: ast.AST) -> ast.AST:  # noqa: D102
+        def in_type_checking_block(self, lineno: int, col_offset: int) -> bool:  # noqa: D102
             ...
 
-        def in_type_checking_block(self, lineno: int, col_offset: int) -> bool:  # noqa: D102
+        def lookup_full_name(self, node: ast.AST) -> str | None:  # noqa: D102
             ...
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-
-        #: Contains a set of all the `Mapped` names that have been imported
-        self.mapped_aliases: set[str] = set()
-
-        #: Contains a dictionary of aliases to one of our dotted names containing one of the `Mapped` names
-        self.mapped_module_aliases: dict[str, str] = {}
 
         #: Contains a set of all names used inside `Mapped[...]` annotations
         # These are treated like soft-uses, i.e. we don't know if it will be
@@ -357,55 +351,6 @@ class SQLAlchemyMixin:
         #: Used for visiting annotations
         self.sqlalchemy_annotation_visitor = SQLAlchemyAnnotationVisitor(self.mapped_names)
 
-    def visit_Import(self, node: ast.Import) -> None:
-        """Record `Mapped` module aliases."""
-        if not self.sqlalchemy_enabled:
-            return
-
-        for name in node.names:
-            # we don't need to map anything
-            if name.asname is None:
-                continue
-
-            prefix = name.name + '.'
-            for dotted_name in self.sqlalchemy_mapped_dotted_names:
-                if dotted_name.startswith(prefix):
-                    self.mapped_module_aliases[name.asname] = name.name
-
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        """Record `Mapped` aliases."""
-        if not self.sqlalchemy_enabled:
-            return
-
-        # we don't try to deal with relative imports
-        if node.module is None or node.level != 0:
-            return
-
-        prefix = node.module + '.'
-        for dotted_name in self.sqlalchemy_mapped_dotted_names:
-            if not dotted_name.startswith(prefix):
-                continue
-
-            suffix = dotted_name[len(prefix) :]
-            if '.' in suffix:
-                # we may need to record a mapped module
-                for name in node.names:
-                    if suffix.startswith(name.name + '.'):
-                        self.mapped_module_aliases[name.asname or name.name] = node.module
-                    elif name.name == '*':
-                        # in this case we can assume that the next segment of the dotted
-                        # name has been imported
-                        self.mapped_module_aliases[suffix.split('.', 1)[0]] = node.module
-                continue
-
-            # we may need to record a mapped name
-            for name in node.names:
-                if suffix == name.name:
-                    self.mapped_aliases.add(name.asname or name.name)
-                elif name.name == '*':
-                    # in this case we can assume it has been imported
-                    self.mapped_aliases.add(suffix)
-
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         """Remove all annotations assigments."""
         if (
@@ -414,6 +359,19 @@ class SQLAlchemyMixin:
             and not self.in_type_checking_block(node.lineno, node.col_offset)
         ):
             self.handle_sqlalchemy_annotation(node.annotation)
+
+    def is_mapped(self, node_or_name: ast.AST | str) -> bool:
+        """Check whether the given node or name should be treated as `Mapped`."""
+        if isinstance(node_or_name, str):
+            try:
+                root_node = ast.parse(f'{node_or_name}: _')
+                ann_assign_node = root_node.body[0]
+                assert isinstance(ann_assign_node, ast.AnnAssign)
+                node_or_name = ann_assign_node.target
+            except Exception:
+                return False
+
+        return self.lookup_full_name(node_or_name) in self.sqlalchemy_mapped_dotted_names
 
     def handle_sqlalchemy_annotation(self, node: ast.AST) -> None:
         """
@@ -435,23 +393,12 @@ class SQLAlchemyMixin:
             mapped_name, inner = annotation.split('[', 1)
             # strip trailing `]` from inner
             inner = inner[:-1]
-            if mapped_name in self.mapped_aliases:
-                # record a use for the name
-                self.uses[mapped_name].append((node, self.current_scope))
+            if not self.is_mapped(mapped_name):
+                return
 
-            elif mapped_name in self.sqlalchemy_mapped_dotted_names:
-                # record a use for the left-most part of the dotted name
-                self.uses[mapped_name.split('.', 1)[0]].append((node, self.current_scope))
-
-            elif '.' in annotation:
-                # try to resolve to a mapped module alias
-                aliased, mapped_name = mapped_name.split('.', 1)
-                module = self.mapped_module_aliases.get(aliased)
-                if module is None or f'{module}.{mapped_name}' not in self.sqlalchemy_mapped_dotted_names:
-                    return
-
-                # record a use for the alias
-                self.uses[aliased].append((node, self.current_scope))
+            # record a use for the first part of the name
+            used_name, *_ = mapped_name.split('.', 1)
+            self.uses[used_name].append((node, self.current_scope))
 
             # add all names contained in the inner part of the annotation
             # since this is not as strict as an actual runtime use, we don't
@@ -467,7 +414,7 @@ class SQLAlchemyMixin:
 
         # simple case only needs to check mapped_aliases
         if isinstance(node.value, ast.Name):
-            if node.value.id not in self.mapped_aliases:
+            if not self.is_mapped(node.value):
                 return
 
             # record a use for the name
@@ -485,7 +432,7 @@ class SQLAlchemyMixin:
                 return
 
             # map the module if it's mapped otherwise use it as is
-            module = self.mapped_module_aliases.get(before_dot.id, before_dot.id)
+            module = self.lookup_full_name(before_dot) or before_dot.id
             dotted_name = f'{module}.{dotted_name}'
             if dotted_name not in self.sqlalchemy_mapped_dotted_names:
                 return
@@ -611,6 +558,9 @@ class ImportName:
     _module: str
     _name: str
     _alias: Optional[str]
+
+    #: Whether or not this import is exempt from TC001-004 checks.
+    exempt: bool
 
     @property
     def module(self) -> str:
@@ -992,15 +942,7 @@ class ImportVisitor(
         self.empty_type_checking_blocks: list[tuple[int, int, int]] = []
         self.type_checking_blocks: list[tuple[int, int, int]] = []
 
-        #: Set to the alias of TYPE_CHECKING if one is found
-        self.type_checking_alias: Optional[str] = None
-
-        #: Set to the alias of typing if one is found
-        self.typing_alias: Optional[str] = None
-
         #: Where typing.cast() is called with an unquoted type.
-        # Used for TC006 errors. Also tracks imported aliases of typing.cast().
-        self.typing_cast_aliases: set[str] = set()
         self.unquoted_types_in_casts: list[tuple[int, int, str]] = []
 
         #: For tracking which comprehension/IfExp we're currently inside of
@@ -1045,26 +987,6 @@ class ImportVisitor(
         return self.annotation_visitor.invalid_binop_literals
 
     @property
-    def typing_module_name(self) -> str:
-        """
-        Return the appropriate module name for the typing import.
-
-        It's possible to do:
-
-            from typing import Set
-                    ^--> module name is `typing`
-
-        but you could also do:
-
-            from typing as t import Set
-                           ^--> module name is `t`
-
-        This property returns the correct module name, accounting
-        for possible aliases.
-        """
-        return self.typing_alias or 'typing'
-
-    @property
     def names(self) -> set[str]:
         """Return unique names."""
         return set(self.uses.keys())
@@ -1076,6 +998,26 @@ class ImportVisitor(
                 for symbol in symbols:
                     if symbol.in_type_checking_block:
                         yield symbol
+
+    def lookup_full_name(self, node: ast.AST) -> str | None:
+        """Lookup the fully qualified name of the given node."""
+        if isinstance(node, ast.Name):
+            imp = self.imports.get(node.id)
+            return imp.full_name if imp is not None else node.id
+
+        if not isinstance(node, ast.Attribute) or not isinstance(node.value, (ast.Name, ast.Attribute)):
+            return None
+
+        prefix = self.lookup_full_name(node.value)
+        return f'{prefix}.{node.attr}'
+
+    def is_typing(self, node: ast.AST, symbol: str) -> bool:
+        """Check if the given node matches the given typing symbol."""
+        full_name = self.lookup_full_name(node)
+        if full_name is None or '.' not in full_name:
+            return False
+
+        return full_name == f'typing.{symbol}' or full_name == f'typing_extensions.{symbol}'
 
     # -- Map type checking block ---------------
 
@@ -1093,15 +1035,12 @@ class ImportVisitor(
 
     def is_type_checking(self, node: ast.AST) -> bool:
         """Determine if the node is equivalent to TYPE_CHECKING."""
-        return (
-            # True for `TYPE_CHECKING`
-            hasattr(node, 'id')
-            and (node.id == 'TYPE_CHECKING')
-            # True for `typing.TYPE_CHECKING` or `T.TYPE_CHECKING`
-            or (hasattr(node, 'attr') and node.attr == 'TYPE_CHECKING')
-            # True for `from typing import TYPE_CHECKING as TC\nTC`
-            or (self.type_checking_alias is not None and hasattr(node, 'id') and (node.id == self.type_checking_alias))
-        )
+        if getattr(node, 'id', '') == 'TYPE_CHECKING':
+            # NOTE: For backwards-compatibility we still allow unqualified
+            #       if TYPE_CHECKING to work, but we may decide to get rid
+            #       of this. We'll just have to change our test cases.
+            return True
+        return self.is_typing(node, 'TYPE_CHECKING')
 
     def is_type_checking_true(self, node: ast.Compare) -> bool:
         """
@@ -1211,7 +1150,12 @@ class ImportVisitor(
 
     def is_exempt_module(self, module_name: str) -> bool:
         """Template module name check."""
-        return any(fnmatch.fnmatch(module_name, exempt_module) for exempt_module in self.exempt_modules)
+        # For backwards compatibility we always treat typing as exempt
+        # although we may wish to change that to a default setting, so
+        # people can override that decision if they choose.
+        return module_name == 'typing' or any(
+            fnmatch.fnmatch(module_name, exempt_module) for exempt_module in self.exempt_modules
+        )
 
     def add_import(self, node: Import) -> None:  # noqa: C901
         """Add relevant ast objects to import lists."""
@@ -1234,61 +1178,36 @@ class ImportVisitor(
                 )
             )
 
-        if in_type_checking_block:
-            # For type checking blocks we want to
-            # Avoid recording imports for TC1XX errors, by returning early
-            return None
-
-        # Skip checking the import if the module is passlisted.
-        if isinstance(node, ast.ImportFrom) and node.module and self.is_exempt_module(node.module):
-            return
+        all_exempt = in_type_checking_block or (
+            isinstance(node, ast.ImportFrom) and node.module and self.is_exempt_module(node.module)
+        )
 
         for name_node in node.names:
             # Skip checking the import if the module is passlisted
-            if isinstance(node, ast.Import) and self.is_exempt_module(name_node.name):
-                return
-
-            # Look for a TYPE_CHECKING import
-            if name_node.name == 'TYPE_CHECKING' and name_node.asname is not None:
-                self.type_checking_alias = name_node.asname
+            exempt = all_exempt or (isinstance(node, ast.Import) and self.is_exempt_module(name_node.name))
 
             # Look for pydantic.validate_arguments import
+            # TODO: Switch to using lookup_full_name instead
             if name_node.name == 'validate_arguments':
                 if name_node.asname is not None:
                     self.pydantic_validate_arguments_import_name = name_node.asname
                 else:
                     self.pydantic_validate_arguments_import_name = name_node.name
 
-            # Look for typing import
-            if name_node.name == 'typing' and name_node.asname is not None:
-                self.typing_alias = name_node.asname
-                return
-
-            # Find aliases of typing.cast()
-            elif (
-                isinstance(node, ast.ImportFrom)
-                and node.level == 0
-                and node.module == self.typing_module_name
-                and name_node.name == 'cast'
-            ):
-                self.typing_cast_aliases.add(name_node.asname or name_node.name)
-
-            elif (isinstance(node, ast.ImportFrom) and node.module == self.typing_module_name) or (
-                isinstance(node, ast.Import) and name_node.name == self.typing_module_name
-            ):
-                # Skip all remaining typing imports, since we already assume
-                # TYPE_CHECKING will be imported at runtime, and guarding the
-                # remaining imports probably won't have any tangible benefit
-                continue
+            exempt = exempt or name_node.name in self.exempt_imports
 
             # Classify and map imports
-            if name_node.name not in self.exempt_imports:
-                imp = ImportName(
-                    _module=f'{node.module}.' if isinstance(node, ast.ImportFrom) else '',
-                    _alias=name_node.asname,
-                    _name=name_node.name,
-                )
+            imp = ImportName(
+                _module=f'{node.module}.' if isinstance(node, ast.ImportFrom) else '',
+                _alias=name_node.asname,
+                _name=name_node.name,
+                exempt=exempt,
+            )
 
+            # Add to import names map. This is what we use to match imports to uses
+            self.imports[imp.name] = imp
+
+            if not exempt:
                 if imp.import_type == Classified.APPLICATION:
                     self.application_imports[imp.import_name] = node
                 elif imp.import_type == Classified.THIRD_PARTY:
@@ -1311,17 +1230,12 @@ class ImportVisitor(
                             # in a file, so we should only need to check this once
                             self.futures_annotation = False
 
-                # Add to import names map. This is what we use to match imports to uses
-                self.imports[imp.name] = imp
-
     def visit_Import(self, node: ast.Import) -> None:
         """Append objects to our import map."""
-        super().visit_Import(node)
         self.add_import(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         """Append objects to our import map."""
-        super().visit_ImportFrom(node)
         self.add_import(node)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> ast.ClassDef:
@@ -1799,16 +1713,7 @@ class ImportVisitor(
         """Find typing.cast() calls with the type argument unquoted."""
         func = node.func
 
-        # Determine whether this is a call to typing.cast() or an alias of it.
-        via_name = isinstance(func, ast.Name) and func.id in self.typing_cast_aliases
-        via_attr = (
-            isinstance(func, ast.Attribute)
-            and isinstance(func.value, ast.Name)
-            and func.value.id == self.typing_module_name
-            and func.attr == 'cast'
-        )
-
-        if not via_name and not via_attr or len(node.args) != 2:
+        if not self.is_typing(func, 'cast') or len(node.args) != 2:
             return  # Not typing.cast() (or an alias) or incorrect number of arguments.
 
         arg = node.args[0]
@@ -1911,8 +1816,9 @@ class TypingOnlyImportsChecker:
             Classified.BUILTIN: (self.visitor.built_in_imports, TC003),
         }
 
-        unused_imports = set(self.visitor.imports) - self.visitor.names - self.visitor.mapped_names
-        used_imports = set(self.visitor.imports) - unused_imports
+        all_imports = {name for name, imp in self.visitor.imports.items() if not imp.exempt}
+        unused_imports = all_imports - self.visitor.names - self.visitor.mapped_names
+        used_imports = all_imports - unused_imports
         already_imported_modules = [self.visitor.imports[name].module for name in used_imports]
         annotation_names = (
             [n for i in self.visitor.wrapped_annotations for n in i.names]

--- a/flake8_type_checking/plugin.py
+++ b/flake8_type_checking/plugin.py
@@ -35,6 +35,13 @@ class Plugin:
     def add_options(cls, option_manager: OptionManager) -> None:  # pragma: no cover
         """Parse plugin options."""
         option_manager.add_option(
+            '--type-checking-typing-modules',
+            comma_separated_list=True,
+            parse_from_config=True,
+            default=[],
+            help='A list of modules whose exports should be treated equivalently to members of the `typing` module.',
+        )
+        option_manager.add_option(
             '--type-checking-exempt-modules',
             comma_separated_list=True,
             parse_from_config=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def _get_error(example: str, *, error_code_filter: Optional[str] = None, **kwarg
         mock_options.enable_extensions = []
         mock_options.type_checking_pydantic_enabled = False
         mock_options.type_checking_exempt_modules = []
+        mock_options.type_checking_typing_modules = []
         mock_options.type_checking_fastapi_enabled = False
         mock_options.type_checking_fastapi_dependency_support_enabled = False
         mock_options.type_checking_pydantic_enabled_baseclass_passlist = []

--- a/tests/test_import_visitors.py
+++ b/tests/test_import_visitors.py
@@ -54,6 +54,9 @@ application_imports = [
     # ast.ImportFrom
     (f'from {mod} import codes', [f'{mod}.codes'], f),
     (f'\nfrom {mod}.codes import TC001', [f'{mod}.codes.TC001'], f),
+    # relative imports
+    ('from . import codes', ['.codes'], f),
+    ('\nfrom .codes import TC001', ['.codes.TC001'], f),
 ]
 
 f = _get_built_in_imports

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -36,32 +36,22 @@ def test_simple_mapped_use(enabled, expected):
 
 
 @pytest.mark.parametrize(
-    ('name', 'expected', 'star_import'),
+    ('name', 'expected'),
     [
-        ('Mapped', set(), False),
-        ('Mapped', set(), True),
-        ('DynamicMapped', set(), False),
-        ('DynamicMapped', set(), True),
-        ('WriteOnlyMapped', set(), False),
-        ('WriteOnlyMapped', set(), True),
+        ('Mapped', set()),
+        ('DynamicMapped', set()),
+        ('WriteOnlyMapped', set()),
         (
             'NotMapped',
             {'2:0 ' + TC002.format(module='foo.Bar'), '3:0 ' + TC002.format(module='sqlalchemy.orm.NotMapped')},
-            False,
-        ),
-        (
-            'NotMapped',
-            # as a star-import it won't trigger TC002, but the other import still will
-            {'2:0 ' + TC002.format(module='foo.Bar')},
-            True,
         ),
     ],
 )
-def test_default_mapped_names(name, expected, star_import):
+def test_default_mapped_names(name, expected):
     """Check the three default names and a bogus name."""
     example = textwrap.dedent(f'''
         from foo import Bar
-        from sqlalchemy.orm import {"*" if star_import else name}
+        from sqlalchemy.orm import {name}
 
         class User:
             x: {name}[Bar]

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -36,22 +36,32 @@ def test_simple_mapped_use(enabled, expected):
 
 
 @pytest.mark.parametrize(
-    ('name', 'expected'),
+    ('name', 'expected', 'star_import'),
     [
-        ('Mapped', set()),
-        ('DynamicMapped', set()),
-        ('WriteOnlyMapped', set()),
+        ('Mapped', set(), False),
+        ('Mapped', set(), True),
+        ('DynamicMapped', set(), False),
+        ('DynamicMapped', set(), True),
+        ('WriteOnlyMapped', set(), False),
+        ('WriteOnlyMapped', set(), True),
         (
             'NotMapped',
             {'2:0 ' + TC002.format(module='foo.Bar'), '3:0 ' + TC002.format(module='sqlalchemy.orm.NotMapped')},
+            False,
+        ),
+        (
+            'NotMapped',
+            # as a star-import it won't trigger TC002, but the other import still will
+            {'2:0 ' + TC002.format(module='foo.Bar')},
+            True,
         ),
     ],
 )
-def test_default_mapped_names(name, expected):
+def test_default_mapped_names(name, expected, star_import):
     """Check the three default names and a bogus name."""
     example = textwrap.dedent(f'''
         from foo import Bar
-        from sqlalchemy.orm import {name}
+        from sqlalchemy.orm import {"*" if star_import else name}
 
         class User:
             x: {name}[Bar]

--- a/tests/test_tc001_to_tc003.py
+++ b/tests/test_tc001_to_tc003.py
@@ -41,6 +41,14 @@ def get_tc_001_to_003_tests(import_: str, ERROR: str) -> L:
         (f'from {import_} import constants as x\ny:x', {'1:0 ' + ERROR.format(module='x')}),
     ]
 
+    if ERROR == TC001:
+        # test relative imports
+        no_use.extend([
+            ('from .. import Plugin\nx:Plugin', {'1:0 ' + ERROR.format(module='..Plugin')}),
+            ('\n\nfrom .foo import constants\nx:constants', {'3:0 ' + ERROR.format(module='.foo.constants')}),
+            ('from . import constants as x\ny:x', {'1:0 ' + ERROR.format(module='x')}),
+        ])
+
     # These imports are all used. None should generate errors.
     used: L = [
         # ast.Import

--- a/tests/test_tc006.py
+++ b/tests/test_tc006.py
@@ -100,10 +100,39 @@ examples = [
     """),
         {'4:7 ' + TC006.format(annotation='int')},
     ),
-    # TODO: What about importing typing.cast() from another module, e.g. a compat module?
+    # re-export of cast using a registered compat module
+    (
+        textwrap.dedent("""
+    from mylib import compat
+
+    compat.cast(int, 3.0)
+    """),
+        {'4:12 ' + TC006.format(annotation='int')},
+    ),
+    (
+        textwrap.dedent("""
+    from .compat import cast
+
+    cast(int, 3.0)
+    """),
+        {'4:5 ' + TC006.format(annotation='int')},
+    ),
+    (
+        textwrap.dedent("""
+    from ..compat import cast
+
+    cast(int, 3.0)
+    """),
+        {'4:5 ' + TC006.format(annotation='int')},
+    ),
 ]
 
 
 @pytest.mark.parametrize(('example', 'expected'), examples)
 def test_TC006_errors(example, expected):
-    assert _get_error(example, error_code_filter='TC006') == expected
+    assert (
+        _get_error(
+            example, error_code_filter='TC006', type_checking_typing_modules=['mylib.compat', '.compat', '..compat']
+        )
+        == expected
+    )

--- a/tests/test_tc006.py
+++ b/tests/test_tc006.py
@@ -100,6 +100,15 @@ examples = [
     """),
         {'4:7 ' + TC006.format(annotation='int')},
     ),
+    # Call function from star-imported module
+    (
+        textwrap.dedent("""
+    from typing import *
+
+    cast(int, 3.0)
+    """),
+        {'4:5 ' + TC006.format(annotation='int')},
+    ),
     # TODO: What about importing typing.cast() from another module, e.g. a compat module?
 ]
 

--- a/tests/test_tc006.py
+++ b/tests/test_tc006.py
@@ -100,15 +100,6 @@ examples = [
     """),
         {'4:7 ' + TC006.format(annotation='int')},
     ),
-    # Call function from star-imported module
-    (
-        textwrap.dedent("""
-    from typing import *
-
-    cast(int, 3.0)
-    """),
-        {'4:5 ' + TC006.format(annotation='int')},
-    ),
     # TODO: What about importing typing.cast() from another module, e.g. a compat module?
 ]
 


### PR DESCRIPTION
This should make some checks a lot more robust and makes it easier to add similarly robust checks to library specific mixins.

This is also a precursor to using `is_typing` in the annotation visitor, so we can handle aliases and module level accesses of `Literal` and `Annotated`.