### PR TITLE
refactor: Make use of `is_typing` for `Literal`/`Annotated` detection.

### DIFF
--- a/flake8_type_checking/checker.py
+++ b/flake8_type_checking/checker.py
@@ -1033,7 +1033,8 @@ class ImportVisitor(
         #: For tracking which comprehension/IfExp we're currently inside of
         self.active_context: Optional[Comprehension | ast.IfExp] = None
 
-        #: Whether we're in a value expression of `typing.Annotated[type, value]`.
+        #: Whether or not we're in a context where uses count as soft-uses.
+        # E.g. the type expression of `typing.Annotated[type, value]`
         self.in_soft_use_context: bool = False
 
     @contextmanager

--- a/flake8_type_checking/types.py
+++ b/flake8_type_checking/types.py
@@ -24,5 +24,9 @@ if TYPE_CHECKING:
         def col_offset(self) -> int:
             pass
 
+    class SupportsIsTyping(Protocol):
+        def is_typing(self, node: ast.AST, symbol: str) -> bool:
+            pass
+
 
 ImportTypeValue = Literal['APPLICATION', 'THIRD_PARTY', 'BUILTIN', 'FUTURE']

--- a/tests/test_name_extraction.py
+++ b/tests/test_name_extraction.py
@@ -1,38 +1,52 @@
+import ast
 import sys
 
 import pytest
 
-from flake8_type_checking.checker import StringAnnotationVisitor
+from flake8_type_checking.checker import ImportVisitor, StringAnnotationVisitor
 
 examples = [
-    ('', set()),
-    ('invalid_syntax]', set()),
-    ('int', {'int'}),
-    ('dict[str, int]', {'dict', 'str', 'int'}),
+    ('', set(), set()),
+    ('invalid_syntax]', set(), set()),
+    ('int', {'int'}, set()),
+    ('dict[str, int]', {'dict', 'str', 'int'}, set()),
     # make sure literals don't add names for their contents
-    ('Literal["a"]', {'Literal'}),
-    ("Literal['a']", {'Literal'}),
-    ('Literal[0]', {'Literal'}),
-    ('Literal[1.0]', {'Literal'}),
-    ('Literal[True]', {'Literal'}),
-    ('T | S', {'T', 'S'}),
-    ('Union[Dict[str, Any], Literal["Foo", "Bar"], _T]', {'Union', 'Dict', 'str', 'Any', 'Literal', '_T'}),
+    ('Literal["a"]', {'Literal'}, set()),
+    ("Literal['a']", {'Literal'}, set()),
+    ('Literal[0]', {'Literal'}, set()),
+    ('Literal[1.0]', {'Literal'}, set()),
+    ('Literal[True]', {'Literal'}, set()),
+    ('L[a]', {'L'}, set()),
+    ('T | S', {'T', 'S'}, set()),
+    ('Union[Dict[str, Any], Literal["Foo", "Bar"], _T]', {'Union', 'Dict', 'str', 'Any', 'Literal', '_T'}, set()),
     # for attribute access only everything up to the first dot should count
     # this matches the behavior of add_annotation
-    ('datetime.date | os.path.sep', {'datetime', 'os'}),
-    ('Nested["str"]', {'Nested', 'str'}),
-    ('Annotated[str, validator]', {'Annotated', 'str'}),
-    ('Annotated[str, "bool"]', {'Annotated', 'str'}),
+    ('datetime.date | os.path.sep', {'datetime', 'os'}, set()),
+    ('Nested["str"]', {'Nested', 'str'}, set()),
+    ('Annotated[str, validator(int, 5)]', {'Annotated', 'str'}, {'validator', 'int'}),
+    ('Annotated[str, "bool"]', {'Annotated', 'str'}, set()),
 ]
 
 if sys.version_info >= (3, 11):
     examples.extend([
-        ('*Ts', {'Ts'}),
+        ('*Ts', {'Ts'}, set()),
     ])
 
 
-@pytest.mark.parametrize(('example', 'expected'), examples)
-def test_name_extraction(example, expected):
-    visitor = StringAnnotationVisitor()
+@pytest.mark.parametrize(('example', 'expected', 'soft_uses'), examples)
+def test_name_extraction(example, expected, soft_uses):
+    import_visitor = ImportVisitor(
+        cwd='fake cwd',  # type: ignore[arg-type]
+        pydantic_enabled=False,
+        fastapi_enabled=False,
+        fastapi_dependency_support_enabled=False,
+        cattrs_enabled=False,
+        sqlalchemy_enabled=False,
+        sqlalchemy_mapped_dotted_names=[],
+        injector_enabled=False,
+        pydantic_enabled_baseclass_passlist=[],
+    )
+    import_visitor.visit(ast.parse('from typing import Annotated, Literal, Literal as L'))
+    visitor = StringAnnotationVisitor(import_visitor)
     visitor.parse_and_visit_string_annotation(example)
     assert visitor.names == expected

--- a/tests/test_name_extraction.py
+++ b/tests/test_name_extraction.py
@@ -6,35 +6,35 @@ import pytest
 from flake8_type_checking.checker import ImportVisitor, StringAnnotationVisitor
 
 examples = [
-    ('', set(), set()),
-    ('invalid_syntax]', set(), set()),
-    ('int', {'int'}, set()),
-    ('dict[str, int]', {'dict', 'str', 'int'}, set()),
+    ('', set()),
+    ('invalid_syntax]', set()),
+    ('int', {'int'}),
+    ('dict[str, int]', {'dict', 'str', 'int'}),
     # make sure literals don't add names for their contents
-    ('Literal["a"]', {'Literal'}, set()),
-    ("Literal['a']", {'Literal'}, set()),
-    ('Literal[0]', {'Literal'}, set()),
-    ('Literal[1.0]', {'Literal'}, set()),
-    ('Literal[True]', {'Literal'}, set()),
-    ('L[a]', {'L'}, set()),
-    ('T | S', {'T', 'S'}, set()),
-    ('Union[Dict[str, Any], Literal["Foo", "Bar"], _T]', {'Union', 'Dict', 'str', 'Any', 'Literal', '_T'}, set()),
+    ('Literal["a"]', {'Literal'}),
+    ("Literal['a']", {'Literal'}),
+    ('Literal[0]', {'Literal'}),
+    ('Literal[1.0]', {'Literal'}),
+    ('Literal[True]', {'Literal'}),
+    ('L[a]', {'L'}),
+    ('T | S', {'T', 'S'}),
+    ('Union[Dict[str, Any], Literal["Foo", "Bar"], _T]', {'Union', 'Dict', 'str', 'Any', 'Literal', '_T'}),
     # for attribute access only everything up to the first dot should count
     # this matches the behavior of add_annotation
-    ('datetime.date | os.path.sep', {'datetime', 'os'}, set()),
-    ('Nested["str"]', {'Nested', 'str'}, set()),
-    ('Annotated[str, validator(int, 5)]', {'Annotated', 'str'}, {'validator', 'int'}),
-    ('Annotated[str, "bool"]', {'Annotated', 'str'}, set()),
+    ('datetime.date | os.path.sep', {'datetime', 'os'}),
+    ('Nested["str"]', {'Nested', 'str'}),
+    ('Annotated[str, validator(int, 5)]', {'Annotated', 'str'}),
+    ('Annotated[str, "bool"]', {'Annotated', 'str'}),
 ]
 
 if sys.version_info >= (3, 11):
     examples.extend([
-        ('*Ts', {'Ts'}, set()),
+        ('*Ts', {'Ts'}),
     ])
 
 
-@pytest.mark.parametrize(('example', 'expected', 'soft_uses'), examples)
-def test_name_extraction(example, expected, soft_uses):
+@pytest.mark.parametrize(('example', 'expected'), examples)
+def test_name_extraction(example, expected):
     import_visitor = ImportVisitor(
         cwd='fake cwd',  # type: ignore[arg-type]
         pydantic_enabled=False,

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -75,6 +75,25 @@ def test_mapped_with_circular_forward_reference():
     assert _get_error(example, error_code_filter='TC002', type_checking_sqlalchemy_enabled=True) == set()
 
 
+def test_mapped_soft_uses():
+    """
+    Everything inside Mapped is a soft-use, including `Annotated` value expresions
+    as such we can't trigger a TC002 here, despite the only uses being inside
+    type annotations.
+    """
+    example = textwrap.dedent('''
+        from foo import Bar, Gt
+        from sqlalchemy.orm import Mapped
+        from typing import Annotated
+
+        class User:
+            number: Mapped[Annotated[Bar, Gt(2)]]
+            bar: Bar
+            validator: Gt
+        ''')
+    assert _get_error(example, error_code_filter='TC002', type_checking_sqlalchemy_enabled=True) == set()
+
+
 def test_mapped_use_without_runtime_import():
     """
     Mapped must be available at runtime, so even if it is inside a wrapped annotation

--- a/tests/test_tc001_to_tc003.py
+++ b/tests/test_tc001_to_tc003.py
@@ -203,6 +203,7 @@ def get_tc_001_to_003_tests(import_: str, ERROR: str) -> L:
                 '''),
             set(),
         ),
+        # Annotated soft use
         (
             textwrap.dedent(f'''
                 from typing import Annotated
@@ -210,9 +211,11 @@ def get_tc_001_to_003_tests(import_: str, ERROR: str) -> L:
                 from {import_} import Depends
 
                 x: Annotated[str, Depends]
+                y: Depends
             '''),
             set(),
         ),
+        # This is not a soft-use, it's just a plain string
         (
             textwrap.dedent(f'''
                 from typing import Annotated
@@ -220,8 +223,9 @@ def get_tc_001_to_003_tests(import_: str, ERROR: str) -> L:
                 from {import_} import Depends
 
                 x: Annotated[str, "Depends"]
+                y: Depends
             '''),
-            set(),
+            {'4:0 ' + ERROR.format(module=f'{import_}.Depends')},
         ),
     ]
 


### PR DESCRIPTION
Makes soft use concept of `mapped_names` more generic and reuse it for walking `Annotated` value expressions.

Closes: #192