### PR TITLE
fix: Avoid false negatives for TC001-003 related to `typing.cast`.

### DIFF
--- a/tests/test_tc001_to_tc003.py
+++ b/tests/test_tc001_to_tc003.py
@@ -323,6 +323,30 @@ def get_tc_001_to_003_tests(import_: str, ERROR: str) -> L:
             ),
             set(),
         ),
+        # Issue #127
+        (
+            textwrap.dedent(
+                f'''
+                from {import_} import Foo
+                from typing import Any, cast
+
+                a = cast('Foo', 1)
+                '''
+            ),
+            {'2:0 ' + ERROR.format(module=f'{import_}.Foo')},
+        ),
+        # forward reference in sub-expression of cast type
+        (
+            textwrap.dedent(
+                f'''
+                from {import_} import Foo
+                from typing import Any, cast
+
+                a = cast(list['Foo'], 1)
+                '''
+            ),
+            {'2:0 ' + ERROR.format(module=f'{import_}.Foo')},
+        ),
     ]
 
     return [


### PR DESCRIPTION
Closes: #127

We could be more aggressive and like with annotations treat even unquoted casts as forward references for the purposes of TC001-003. But I'm not sure it's the right call. Going the other way and recording them as uses seems bad too, due to the conflicting TC004/TC006 errors that will create, so the status quo should be fine for now.

If we can properly handle forward references that's already a huge win.