### PR TITLE
refactor: Simplifies attrs support

### DIFF
--- a/flake8_type_checking/constants.py
+++ b/flake8_type_checking/constants.py
@@ -16,7 +16,6 @@ ATTRS_DECORATORS = [
     'attr.mutable',
     'attr.s',
 ]
-ATTRS_IMPORTS = {'attrs', 'attr'}
 
 flake_version_gt_v4 = tuple(int(i) for i in flake8.__version__.split('.')) >= (4, 0, 0)
 

--- a/flake8_type_checking/types.py
+++ b/flake8_type_checking/types.py
@@ -5,16 +5,12 @@ from typing import TYPE_CHECKING, Literal
 if TYPE_CHECKING:
     import ast
     from collections.abc import Generator
-    from typing import Any, Optional, Protocol, Union
+    from typing import Any, Protocol, Union
 
     Function = Union[ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda]
     Comprehension = Union[ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp]
     Import = Union[ast.Import, ast.ImportFrom]
     Flake8Generator = Generator[tuple[int, int, str, Any], None, None]
-
-    class Name(Protocol):
-        asname: Optional[str]
-        name: str
 
     class HasPosition(Protocol):
         @property


### PR DESCRIPTION
Gets rid of some complex code we no longer need, since `lookup_full_name` already gives us what we want.